### PR TITLE
Documentation: Fixes typo on array builtin functions examples.

### DIFF
--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -92,7 +92,7 @@ The concatenation of the two input lists
 
 > **input**
 ```scriban-html
-{{ [1, 2, 3] | array.concat [4, 5] }}
+{{ [1, 2, 3] | array.add_range [4, 5] }}
 ```
 > **output**
 ```html


### PR DESCRIPTION
* Updates documentation for array builtins. Fixes typo on add_range example.

Behavior has been tested to ensure it matches this updated example.