### PR TITLE
Fix for issue-295, malformed input causing  NRE

### DIFF
--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -322,6 +322,19 @@ raw
             AssertRoundtrip(text);
         }
 
+        /// <summary>
+        /// Regression test for issue-295
+        /// </summary>
+        [Test]
+        public void ShouldNotThrowWithTrailingColon()
+        {
+            //this particular input string is required to tickle the original bug
+            var text = @"{{T ""m"" b:";
+            var context = new TemplateContext();
+            context.PushGlobal(new ScriptObject());
+            Assert.DoesNotThrow(() => Template.Parse(text));
+        }
+
         [Test]
         public void TestDateNow()
         {

--- a/src/Scriban/Parsing/Parser.Expressions.cs
+++ b/src/Scriban/Parsing/Parser.Expressions.cs
@@ -484,7 +484,11 @@ namespace Scriban.Parsing
                                     parameter.ColonToken = ScriptToken.Colon();
                                     ExpectAndParseTokenTo(parameter.ColonToken, TokenType.Colon);
                                     parameter.Value = ExpectAndParseExpression(parentNode, mode: ParseExpressionMode.BasicExpression);
-                                    parameter.Span.End = parameter.Value.Span.End;
+                                    // Certain patterns of malformed input (see issue-295) can cause the expression parser to return null
+                                    // at this point.  In that case, leave the span empty
+                                    if (parameter.Value != null)
+                                        parameter.Span.End = parameter.Value.Span.End;
+                                   
                                 }
 
                                 if (functionCall != null)


### PR DESCRIPTION
I've addressed the issue by leaving the Span at its initial value.  A couple of assumption behind this...

- The initial Span is empty rather than in some inconsistent state.
- A value of 'null' for parameter.Value  is valid and meaningful.  (This seems to be the case looking at related code.)