### PR TITLE
Fix for issue-298, include operation failing when strictVariables set

### DIFF
--- a/src/Scriban.Tests/TestIncludes.cs
+++ b/src/Scriban.Tests/TestIncludes.cs
@@ -13,6 +13,34 @@ namespace Scriban.Tests
 {
     public class TestIncludes
     {
+
+        internal class DummyLoader : ITemplateLoader
+        {
+            public string GetPath(TemplateContext context, SourceSpan callerSpan, string templateName)
+                => templateName;
+
+            public string Load(TemplateContext context, SourceSpan callerSpan, string templatePath)
+                => "some text";
+
+            public ValueTask<string> LoadAsync(TemplateContext context, SourceSpan callerSpan, string templatePath)
+                => ValueTask.FromResult(Load(context, callerSpan, templatePath));
+        }
+
+        [Test]
+        public void IncludeShouldNotThrowWhenStrictVariablesSet()
+        {
+            var text = @"{{include 'testfile'}}";
+            var context = new TemplateContext { TemplateLoader = new DummyLoader() };
+            //NOTE - setting strict variables causes the test to fail
+            context.StrictVariables = true;
+            var compiledTemplate = Template.Parse(text);
+            context.PushGlobal(new ScriptObject());
+
+            var result = compiledTemplate.Render(context);
+            Assert.AreEqual(result,"some text");
+        }
+
+
         [Test]
         public void TestLoopWithInclude()
         {

--- a/src/Scriban/TemplateContext.Variables.cs
+++ b/src/Scriban/TemplateContext.Variables.cs
@@ -432,7 +432,8 @@ namespace Scriban
 
         private void CheckVariableFound(ScriptVariable variable, bool found)
         {
-            if (StrictVariables && !found)
+            //ScriptVariable.Arguments is a special "magic" variable which is not always present so ignore this
+            if (StrictVariables && !found && variable != ScriptVariable.Arguments)
             {
                 throw new ScriptRuntimeException(variable.Span, $"The variable or function `{variable}` was not found");
             }


### PR DESCRIPTION
I'm not completely sure this is the best fix.  I _think_ '$' (ScriptVariable.Arguments) is meant to be a list of arguments to the invoked context and so may not always be relevant.  Maybe it would be better to ensure it is always present?