### PR TITLE
Upgrade Fluid in benchmark project

### DIFF
--- a/src/Scriban.Benchmarks/Scriban.Benchmarks.csproj
+++ b/src/Scriban.Benchmarks/Scriban.Benchmarks.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -17,7 +17,7 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="Cottle" Version="2.0.2" />
     <PackageReference Include="DotLiquid" Version="2.0.366" />
-    <PackageReference Include="Fluid.Core" Version="1.0.0-beta-9545" />
+    <PackageReference Include="Fluid.Core" Version="2.0.0-beta-1001" />
     <PackageReference Include="Handlebars.Net" Version="1.11.5" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="3.1.3" />
     <PackageReference Include="Nustache" Version="1.16.0.10" />


### PR DESCRIPTION
Upgrading Fluid in benchmark project to version 2.x which now utilizes the new [Parlot](https://github.com/sebastienros/parlot/) parsing engine.

/cc @sebastienros

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-6820HQ CPU 2.70GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.102
  [Host]     : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT
  DefaultJob : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT


```
|                    Method |       Mean |     Error |    StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------------------- |-----------:|----------:|----------:|--------:|-------:|------:|----------:|
|        &#39;Scriban - Parser&#39; |  18.923 μs | 0.2507 μs | 0.2222 μs |  1.5869 |      - |     - |   6.49 KB |
| &#39;Scriban Liquid - Parser&#39; |  22.755 μs | 0.0712 μs | 0.0594 μs |  1.8005 |      - |     - |   7.41 KB |
|      &#39;DotLiquid - Parser&#39; |  52.585 μs | 0.5841 μs | 0.5463 μs |  2.6855 |      - |     - |  11.17 KB |
|        &#39;Stubble - Parser&#39; |  13.278 μs | 0.0581 μs | 0.0515 μs |  2.5024 |      - |     - |  10.26 KB |
|       &#39;Nustache - Parser&#39; |  42.878 μs | 0.8406 μs | 0.8995 μs |  4.7607 |      - |     - |  19.55 KB |
| &#39;Handlebars.NET - Parser&#39; | 974.924 μs | 2.1324 μs | 1.7806 μs | 15.6250 | 1.9531 |     - |  69.97 KB |
|         &#39;Cottle - Parser&#39; |  10.835 μs | 0.0992 μs | 0.0879 μs |  3.0212 |      - |     - |  12.38 KB |
|          &#39;Fluid - Parser&#39; |   8.507 μs | 0.0697 μs | 0.0618 μs |  0.6714 |      - |     - |   2.77 KB |


``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-6820HQ CPU 2.70GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.102
  [Host]     : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT
  DefaultJob : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT


```
|       Method |        Mean |     Error |    StdDev |      Median |     Gen 0 |    Gen 1 |   Gen 2 |   Allocated |
|------------- |------------:|----------:|----------:|------------:|----------:|---------:|--------:|------------:|
|      Scriban |    925.1 μs |   6.05 μs |   5.05 μs |    923.5 μs |   39.0625 |  29.2969 | 29.2969 |    220.4 KB |
| ScribanAsync |  3,129.0 μs |  19.00 μs |  17.77 μs |  3,126.6 μs |   39.0625 |  27.3438 | 27.3438 |   220.64 KB |
|    DotLiquid |  6,817.6 μs | 134.70 μs | 317.51 μs |  6,632.1 μs |  890.6250 | 187.5000 | 23.4375 |  3737.77 KB |
|      Stubble |  2,274.7 μs |   9.49 μs |   8.41 μs |  2,272.9 μs |  656.2500 |  85.9375 | 27.3438 |   2767.8 KB |
|     Nustache | 23,899.3 μs |  67.42 μs |  52.63 μs | 23,902.0 μs | 3812.5000 |        - |       - | 15758.21 KB |
|   Handlebars |  6,874.9 μs |  77.48 μs |  60.49 μs |  6,851.6 μs |  257.8125 |  54.6875 | 23.4375 |  1129.93 KB |
|       Cottle |    533.6 μs |  10.45 μs |  16.87 μs |    524.3 μs |   96.6797 |  32.2266 |       - |   397.93 KB |
|        Fluid |    659.4 μs |   4.08 μs |   3.19 μs |    658.8 μs |   42.9688 |  10.7422 |       - |   179.18 KB |
