### PR TITLE
always return AST, even if it contains errors

### DIFF
--- a/src/Scriban/Parsing/Parser.cs
+++ b/src/Scriban/Parsing/Parser.cs
@@ -165,7 +165,7 @@ namespace Scriban.Parsing
                 }
             }
 
-            return !HasErrors ? page : null;
+            return page;
         }
 
         private void PushTokenToTrivia()


### PR DESCRIPTION
It would be nice to have access to AST even if is not entirely correct. Anything is better than null/nothing. 