### PR TITLE
Ensure that attempting to render object with indexed property does not crash

### DIFF
--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using DotLiquid.Tests.Tags;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Scriban.Helpers;
 using Scriban.Parsing;
@@ -606,6 +607,17 @@ end
         {
             AssertTemplate(output, input);
         }
+
+
+        [Test]
+        public void EnsureThatItemWithIndexePropertyDoesNotThrow()
+        {
+            var obj = JObject.Parse("{\"name\":\"steve\"}");
+          
+            var template = Template.Parse("Hi {{name}}");
+            Assert.DoesNotThrow(()=>template.Render(obj));
+        }
+
 
         private static void TestFile(string inputName)
         {

--- a/src/Scriban/Runtime/ScriptObjectExtensions.cs
+++ b/src/Scriban/Runtime/ScriptObjectExtensions.cs
@@ -284,7 +284,8 @@ namespace Scriban.Runtime
                             }
                             else
                             {
-                                scriptObj.SetValue(newPropertyName, property.GetValue(obj), false);
+                                if (property.GetIndexParameters().Length==0)
+                                    scriptObj.SetValue(newPropertyName, property.GetValue(obj), false);
                             }
                         }
                     }


### PR DESCRIPTION
This does not allow the directly rendering of JObjects (as described in #311) but it does at least prevent the renderer crashing if you try to pass in an object that uses indexed properties.  (See https://stackoverflow.com/questions/18721920/parameter-count-mismatch-exception-when-calling-propertyinfo-getvalue) There _might_ be a handle this more intelligently than just discarding the problematic property but I couldn't immediately see a way of figuring out appropriate values for the indexers that would be needed to fetch the property values.  