### PR TITLE
Ensure badly formed function declarations do not break parser

### DIFF
--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -617,7 +617,11 @@ end
             var template = Template.Parse("Hi {{name}}");
             Assert.DoesNotThrow(()=>template.Render(obj));
         }
-
+        [Test]
+        public void EnsureMalformedFunctionDoesNotThrow()
+        {
+            Assert.DoesNotThrow(() =>Template.Parse("{{ func (t("));
+        }
 
         private static void TestFile(string inputName)
         {

--- a/src/Scriban/Parsing/Parser.Statements.Scriban.cs
+++ b/src/Scriban/Parsing/Parser.Statements.Scriban.cs
@@ -259,6 +259,8 @@ namespace Scriban.Parsing
                             var arg = ExpectAndParseVariable(scriptFunction);
                             if (!(arg is ScriptVariableGlobal))
                             {
+                                if (arg == null)
+                                    break;
                                 LogError(arg.Span, "Expecting only a simple name parameter for a function");
                             }
 


### PR DESCRIPTION
Fixes #313

I think the immediate break is the right thing here?  We already get an error logged by ExpectAndParseVariable so no need for a new one.