### PR TITLE
Invalid AST : Return valid part of member expression

### DIFF
--- a/src/Scriban/Parsing/Parser.Expressions.cs
+++ b/src/Scriban/Parsing/Parser.Expressions.cs
@@ -245,7 +245,7 @@ namespace Scriban.Parsing
                         else
                         {
                             LogError(nextToken, $"Invalid token `{nextToken.Type}`. The dot operator is expected to be followed by a plain identifier");
-                            return null;
+                            return leftOperand;
                         }
                         continue;
                     }


### PR DESCRIPTION
For given incomplete template:
```
{{  if dto. }}
```
when parser finds problem in expression, in that case lack of identifier after dot, it does not include whole expression in AST:
```
ScriptPage (0 - 9)
  ScriptBlockStatement (0 - 9)
    ScriptEscapeStatement (0 - 1)  [{{]
    ScriptIfStatement (4 - 9)
      ScriptKeyword (4 - 5)  [if]
  ScriptBlockStatement END
```
after small change done in this pull request, the valid part of expression will be returned:

```
ScriptPage (0 - 9)
  ScriptBlockStatement (0 - 9)
    ScriptEscapeStatement (0 - 1)  [{{]
    ScriptIfStatement (4 - 9)
      ScriptKeyword (4 - 5)  [if]
      ScriptVariableGlobal (7 - 9)  [dto]
  ScriptBlockStatement END
```



