### PR TITLE
Basic investigation of exception thrown during evaluate process.

### DIFF
--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -78,6 +78,21 @@ namespace Scriban.Tests
         }
 
         [Test]
+        public void TestEvaluateProcessing()
+        {
+            {
+                var result = Template.Parse("{{['', '200', '','400'] | array.filter @string.strip}}").Evaluate(new TemplateContext());
+
+                Assert.AreEqual(new[] { "", "200", "", "400" }, result);
+            }
+            {
+                var result = Template.Parse("{{['', '200', '','400'] | array.filter @string.empty}}").Evaluate(new TemplateContext());
+
+                Assert.AreEqual(new[] { "", "" }, result);
+            }
+        }
+
+        [Test]
 
         public void TestScientificWithFunctionExpression()
         {

--- a/src/Scriban/TemplateContext.cs
+++ b/src/Scriban/TemplateContext.cs
@@ -746,7 +746,7 @@ namespace Scriban
             }
             finally
             {
-                CurrentNode = previousNode;
+                CurrentNode = previousNode ?? CurrentNode;
                 _getOrSetValueLevel = previousLevel;
                 _isFunctionCallDisabled = previousFunctionCallState;
             }


### PR DESCRIPTION
It's not a completed code, it's more like a question.

I found a reason I think, for the latest loop step, Current node is set to null but the node is mandatory context for all internal array functions.
I've added a code to demonstrate that.

Do you have anything to suggest what else I can check?