### PR TITLE
Force ScriptRanges to be evaluated as ScriptArrays before popping context

### DIFF
--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -644,60 +644,7 @@ call_array true -}}";
             Assert.AreEqual("[1, 2, 3]",template.Render());
         }
 
-
-        [Test]
-        public void LocalFunctionHasAccessToForLoopControlVariable()
-        {
-            var templateString = @"{{-
-for a in [99]
-   fn=@(do;ret a;end)
-  fn  
-end
--}}";
-            var template = Template.Parse(templateString);
-            Assert.AreEqual("99", template.Render());
-        }
-
-        [Test]
-        public void RetLocalFunctionHasAccessToForLoopControlVariable()
-        {
-            var templateString = @"{{-
-for a in [99]
-   fn=@(do;ret a;end)
-  ret fn  
-end
--}}";
-            var template = Template.Parse(templateString);
-            Assert.AreEqual("99", template.Render());
-        }
-
-
-        [Test]
-        public void ArrayIteratorHasAccessToLoopControlVariable()
-        {
-            var templateString = @"{{-
-for a in [99]
-   fn=@(do;ret a;end)
-   ret [1,2,3] | array.each @fn 
-end
--}}";
-            var template = Template.Parse(templateString);
-            Assert.AreEqual( "[99, 99, 99]", template.Render());
-        }
-
-        [Test]
-        public void RetArrayIteratorHasAccessToLoopControlVariable()
-        {
-            var templateString = @"{{-
-for a in [99]
-   fn=@(do;ret a;end)
-   [1,2,3] | array.each @fn 
-end
--}}";
-            var template = Template.Parse(templateString);
-            Assert.AreEqual("[99, 99, 99]", template.Render());
-        }
-
+      
         [Test]
         public void TopLevelAnonymousFunctionCanAccessGloba()
         {
@@ -709,7 +656,6 @@ a=99
             var template = Template.Parse(templateString);
             Assert.AreEqual("99", template.Render());
         }
-
 
         [Test]
         public void TestEvaluateProcessing()

--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -638,37 +638,77 @@ end
 func call_array(p)
   ret  [1,2,3] | array.filter @(do;ret p;end)
 end
-call_array true -}}
-";
+call_array true -}}";
 
             var template = Template.Parse(templateString);
-            var context = new TemplateContext();
-            var result = template.Render(context);
-            Assert.AreEqual(result, "[1, 2, 3]");
+            Assert.AreEqual("[1, 2, 3]",template.Render());
         }
 
 
         [Test]
-        public void ArrayIteratorHasAccessToContextLoop()
+        public void LocalFunctionHasAccessToForLoopControlVariable()
         {
-
             var templateString = @"{{-
-
 for a in [99]
    fn=@(do;ret a;end)
   fn  
 end
--}}
-";
-
+-}}";
             var template = Template.Parse(templateString);
-            var context = new TemplateContext();
-            context.StrictVariables = true;
-            var result = template.Render(context);
-            Assert.AreEqual(result, "99");
+            Assert.AreEqual("99", template.Render());
+        }
+
+        [Test]
+        public void RetLocalFunctionHasAccessToForLoopControlVariable()
+        {
+            var templateString = @"{{-
+for a in [99]
+   fn=@(do;ret a;end)
+  ret fn  
+end
+-}}";
+            var template = Template.Parse(templateString);
+            Assert.AreEqual("99", template.Render());
         }
 
 
+        [Test]
+        public void ArrayIteratorHasAccessToLoopControlVariable()
+        {
+            var templateString = @"{{-
+for a in [99]
+   fn=@(do;ret a;end)
+   ret [1,2,3] | array.each @fn 
+end
+-}}";
+            var template = Template.Parse(templateString);
+            Assert.AreEqual( "[99, 99, 99]", template.Render());
+        }
+
+        [Test]
+        public void RetArrayIteratorHasAccessToLoopControlVariable()
+        {
+            var templateString = @"{{-
+for a in [99]
+   fn=@(do;ret a;end)
+   [1,2,3] | array.each @fn 
+end
+-}}";
+            var template = Template.Parse(templateString);
+            Assert.AreEqual("[99, 99, 99]", template.Render());
+        }
+
+        [Test]
+        public void TopLevelAnonymousFunctionCanAccessGloba()
+        {
+            var templateString = @"{{-
+a=99
+   fn=@(do;ret a;end)
+   fn
+-}}";
+            var template = Template.Parse(templateString);
+            Assert.AreEqual("99", template.Render());
+        }
 
 
         private static void TestFile(string inputName)

--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -638,8 +638,6 @@ end
 func call_array(p)
   ret  [1,2,3] | array.filter @(do;ret p;end)
 end
-
-#This fails: parameter is not found at line 14 when calling into array iterator
 call_array true -}}
 ";
 

--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -711,6 +711,22 @@ a=99
         }
 
 
+        [Test]
+        public void TestEvaluateProcessing()
+        {
+            {
+                var result = Template.Parse("{{['', '200', '','400'] | array.filter @string.strip}}").Evaluate(new TemplateContext());
+
+                Assert.AreEqual(new[] { "", "200", "", "400" }, result);
+            }
+            {
+                var result = Template.Parse("{{['', '200', '','400'] | array.filter @string.empty}}").Evaluate(new TemplateContext());
+
+                Assert.AreEqual(new[] { "", "" }, result);
+            }
+        }
+
+
         private static void TestFile(string inputName)
         {
             var filename = Path.GetFileName(inputName);

--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -648,6 +648,29 @@ call_array true -}}
         }
 
 
+        [Test]
+        public void ArrayIteratorHasAccessToContextLoop()
+        {
+
+            var templateString = @"{{-
+
+for a in [99]
+   fn=@(do;ret a;end)
+  fn  
+end
+-}}
+";
+
+            var template = Template.Parse(templateString);
+            var context = new TemplateContext();
+            context.StrictVariables = true;
+            var result = template.Render(context);
+            Assert.AreEqual(result, "99");
+        }
+
+
+
+
         private static void TestFile(string inputName)
         {
             var filename = Path.GetFileName(inputName);

--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -630,6 +630,25 @@ end
         {
             Assert.DoesNotThrow(() =>Template.Parse("{{ func (t("));
         }
+        [Test]
+        public void ArrayIteratorHasAccessToContext()
+        {
+
+            var templateString = @"{{-
+func call_array(p)
+  ret  [1,2,3] | array.filter @(do;ret p;end)
+end
+
+#This fails: parameter is not found at line 14 when calling into array iterator
+call_array true -}}
+";
+
+            var template = Template.Parse(templateString);
+            var context = new TemplateContext();
+            var result = template.Render(context);
+            Assert.AreEqual(result, "[1, 2, 3]");
+        }
+
 
         private static void TestFile(string inputName)
         {

--- a/src/Scriban/Syntax/Expressions/ScriptFunctionCall.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptFunctionCall.cs
@@ -325,9 +325,11 @@ namespace Scriban.Syntax
         public static object Call(TemplateContext context, ScriptNode callerContext, IScriptCustomFunction function, ScriptArray arguments)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
-            if (callerContext == null) throw new ArgumentNullException(nameof(callerContext));
             if (function == null) throw new ArgumentNullException(nameof(function));
             if (arguments == null) throw new ArgumentNullException(nameof(arguments));
+            //this can happen if we're calling an anonymous function from the top level
+            if (callerContext == null)
+                callerContext = new ScriptAnonymousFunction();
 
             var parameterCount = function.ParameterCount;
 

--- a/src/Scriban/Syntax/Statements/ScriptFunction.cs
+++ b/src/Scriban/Syntax/Statements/ScriptFunction.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Runtime.InteropServices;
 using Scriban.Parsing;
 using Scriban.Runtime;
 
@@ -225,7 +226,15 @@ namespace Scriban.Syntax
                     context.SetValue(ScriptVariable.BlockDelegate, blockStatement, true);
                 }
 
-                return context.Evaluate(Body);
+                var result = context.Evaluate(Body);
+                //if the result of the evaluation was a ScriptRange that depended on local variables
+                //then we need to force the deferred enumerable inside the range to be evaluated right now
+                //before we pop the variables out of the context!
+                if (result is ScriptRange range)
+                {
+                    result = new ScriptArray(range);
+                }
+                return result;
             }
             finally
             {

--- a/src/Scriban/Syntax/Statements/ScriptFunction.cs
+++ b/src/Scriban/Syntax/Statements/ScriptFunction.cs
@@ -5,7 +5,6 @@
 #nullable disable
 
 using System;
-using System.Runtime.InteropServices;
 using Scriban.Parsing;
 using Scriban.Runtime;
 
@@ -231,9 +230,7 @@ namespace Scriban.Syntax
                 //then we need to force the deferred enumerable inside the range to be evaluated right now
                 //before we pop the variables out of the context!
                 if (result is ScriptRange range)
-                {
                     result = new ScriptArray(range);
-                }
                 return result;
             }
             finally

--- a/src/Scriban/Syntax/Statements/ScriptReturnStatement.cs
+++ b/src/Scriban/Syntax/Statements/ScriptReturnStatement.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using Scriban.Runtime;
 using System.Collections.Generic;
 
 namespace Scriban.Syntax
@@ -39,6 +40,9 @@ namespace Scriban.Syntax
         public override object Evaluate(TemplateContext context)
         {
             var result = context.Evaluate(Expression);
+            //ensure that deferred array interators are evaluated before we lose context
+            if (result is ScriptRange range)
+                result = new ScriptArray(range);
             context.FlowState = ScriptFlowState.Return;
             return result;
         }

--- a/src/Scriban/TemplateContext.Variables.cs
+++ b/src/Scriban/TemplateContext.Variables.cs
@@ -266,20 +266,13 @@ namespace Scriban
 
             if (IsInLoop)
             {
-                //seach back through the stack of contexts in case we are
-                //looking for a loop variable from with a local function invocation
-                var contextStack = _localContexts;
-                for (int contextIndex = contextStack.Count - 1; contextIndex >= 0; contextIndex--)
+                var count = _currentLocalContext.Loops.Count;	               
+                var items = _currentLocalContext.Loops.Items;
+                for (int i = count - 1; i >= 0; i--)
                 {
-                    var context = contextStack.Items[contextIndex];
-                    var count = context.Loops.Count;
-                    var items = context.Loops.Items;
-                    for (int i = count - 1; i >= 0; i--)
+                    if (items[i].TryGetValue(this, variable.Span, variable.Name, out value))
                     {
-                        if (items[i].TryGetValue(this, variable.Span, variable.Name, out value))
-                        {
-                            return value;
-                        }
+                        return value;
                     }
                 }
             }

--- a/src/Scriban/TemplateContext.Variables.cs
+++ b/src/Scriban/TemplateContext.Variables.cs
@@ -266,13 +266,20 @@ namespace Scriban
 
             if (IsInLoop)
             {
-                var count = _currentLocalContext.Loops.Count;
-                var items = _currentLocalContext.Loops.Items;
-                for (int i = count - 1; i >= 0; i--)
+                //seach back through the stack of contexts in case we are
+                //looking for a loop variable from with a local function invocation
+                var contextStack = _localContexts;
+                for (int contextIndex = contextStack.Count - 1; contextIndex >= 0; contextIndex--)
                 {
-                    if (items[i].TryGetValue(this, variable.Span, variable.Name, out value))
+                    var context = contextStack.Items[contextIndex];
+                    var count = context.Loops.Count;
+                    var items = context.Loops.Items;
+                    for (int i = count - 1; i >= 0; i--)
                     {
-                        return value;
+                        if (items[i].TryGetValue(this, variable.Span, variable.Name, out value))
+                        {
+                            return value;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This was the highest place I could find to do this.  Unfortunately I don't have a good enough understanding of the codebase to figure out whether it's going to kill performance in some way.  

I did consider adding a mode flag to TemplateContext (AllowVariableCapture) which would allow users to opt in to the slower-but-more-powerful syntax but that seems very much like a last resort.

Also, this does *not* address #320   It seems the that issues has the same root cause - deferred evaluation of the ScriptRange after the context has been popped but I couldn't track down the return path for that particular scenario.