### PR TITLE
Implement some missing interface methods.

### DIFF
--- a/src/Scriban/Runtime/ScriptRange.cs
+++ b/src/Scriban/Runtime/ScriptRange.cs
@@ -576,7 +576,7 @@ namespace Scriban.Runtime
 
         void IList.Remove(object value)
         {
-            throw new NotImplementedException();
+            Remove(value);
         }
 
         public void RemoveAt(int index)


### PR DESCRIPTION
ScriptObject got a more efficient implementation of ``IEnumerator`2.GetEnumerator``, a correct implementation of ``ICollection`1.IsReadOnly`` and non-throwing implementations of four ``ICollection`1`` members (`CopyTo` in particular is used by Rider's debugger and hindered debugging experience by throwing).
Furthermore `ScriptRange`'s `IList.Remove` was trivially implemented.