### PR TITLE
Fixes a potential stack overflow if the object graph contains cycles

### DIFF
--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -654,6 +654,21 @@ end
             }
         }
 
+        [Test]
+        public void EnsureStackOverflowCanBeAvoidedForSelfReferentialObjectGraphs()
+        {
+            var script = @"{{
+m ={a:0}
+m.a =m
+m
+}}";
+            var template = Template.Parse(script);
+            var context = new TemplateContext
+            {
+                ObjectRecursionLimit = 100
+            };
+            Assert.Throws<ScriptRuntimeException>(() => template.Render(context));
+        }
 
         private static void TestFile(string inputName)
         {

--- a/src/Scriban/TemplateContext.Helpers.cs
+++ b/src/Scriban/TemplateContext.Helpers.cs
@@ -96,6 +96,8 @@ namespace Scriban
             try
             {
                 _objectToStringLevel++;
+                if (ObjectRecursionLimit != 0 && _objectToStringLevel > ObjectRecursionLimit)
+                    throw new InvalidOperationException("Structure is too deeply nested or contains reference loops.");
                 var result = ObjectToStringImpl(value, shouldEscapeString);
                 if (LimitToString > 0 && _objectToStringLevel  == 1 && result != null && result.Length >= LimitToString)
                 {

--- a/src/Scriban/TemplateContext.cs
+++ b/src/Scriban/TemplateContext.cs
@@ -123,6 +123,7 @@ namespace Scriban
             LoopLimit = 1000;
             RecursiveLimit = 100;
             LimitToString = 0;
+            ObjectRecursionLimit=0;
             MemberRenamer = StandardMemberRenamer.Default;
 
             RegexTimeOut = TimeSpan.FromSeconds(10);
@@ -197,6 +198,11 @@ namespace Scriban
         /// Gets or sets the buffer limit in characters for a ToString in a list/string. Default is 0, no limit.
         /// </summary>
         public int LimitToString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum recursion depth while traversing an object graph during the ToString operation.  Default is 0, no limit
+        /// </summary>
+        public int ObjectRecursionLimit { get; set; }
 
         /// <summary>
         /// String used for new-line.


### PR DESCRIPTION
It's unfortunately quite easy to create cyclical object graphs in [TextrudeInteractive](https://github.com/NeilMacMullen/Textrude) since the script is re-rendered after each keystroke.  For example, en-route to typing `model.newProperty=model.a+model.b` the user will, at some point, have a line reading `model.newProperty=model`.  If this is then rendered to a string, Scriban will throw an uncatchable **StackOverflowException** as it repeatedly traverses `TemplateContext.ObjectToString` and `ScriptObject.ToString`.

This change introduces an `ObjectRecursionLimit` property on `TemplateContext` which is checked against the existing `_objectToStringLevel` field.  It defaults to 0 (i.e disabled) to preserve the old behaviour unless explicitly set.

