### PR TITLE
add complementary operator to null-coalescing operator (??) -> (?!)

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -43,7 +43,7 @@ The language rules are the same in a pure scripting context.
   - [8.5 Conditional expressions](#85-conditional-expressions)
   - [8.6 Unary expressions](#86-unary-expressions)
   - [8.7 Range expressions](#87-range-expressions)
-  - [8.8 The null-coalescing operator <code>??</code>](#88-the-null-coalescing-operator-)
+  - [8.8 The null-coalescing operators <code>??</code>, <code>?!</code>](#88-the-null-coalescing-operator-)
   - [8.9 Function call expression](#89-function-call-expression)
     - [Named arguments](#named-arguments)
 - [9 Statements](#9-statements)
@@ -889,9 +889,11 @@ The evaluated `left` and `right` expressions must resolve to an integer at runti
 | `left..right`   | Returns an iterator between `left` and `right` with a step of 1, including `right`. e.g: `1..5` iterates from 1 to 5
 | `left..<right`  | Returns an iterator between `left` and `right` with a step of 1, excluding `right`. e.g: `1..<5` iterates from 1 to 4
 
-### 8.8 The null-coalescing operator `??` 
+### 8.8 The null-coalescing operators `??`, `?!` 
 
 The operator `left ?? right` can be used to return the `right` value if `left` is null.
+
+The operator `left ?! right` can be used to return the `right` value if `left` is not null.
 
 [:top:](#language)
 ### 8.9 Function call expression

--- a/src/Scriban.Tests/TestFiles/100-expressions/110-binary-simple.out.txt
+++ b/src/Scriban.Tests/TestFiles/100-expressions/110-binary-simple.out.txt
@@ -40,6 +40,10 @@ null ?? 1 -> 1
 1 ?? null -> 1
 test ?? "yes" -> yes
 
+null ?! 1 -> 
+1 ?! null -> 
+1 ?! "yes" -> yes
+
 5 + math.abs(-2) -> 7
 
 null == null -> true

--- a/src/Scriban.Tests/TestFiles/100-expressions/110-binary-simple.txt
+++ b/src/Scriban.Tests/TestFiles/100-expressions/110-binary-simple.txt
@@ -40,6 +40,10 @@ null ?? 1 -> {{ null ?? 1 }}
 1 ?? null -> {{ 1 ?? null }}
 test ?? "yes" -> {{ test ?? "yes" }}
 
+null ?! 1 -> {{ null ?! 1 }}
+1 ?! null -> {{ 1 ?! null }}
+1 ?! "yes" -> {{ 1 ?! "yes" }}
+
 5 + math.abs(-2) -> {{ 5 + math.abs (-2) }}
 
 null == null -> {{ null == null }}

--- a/src/Scriban.Tests/TestLexer.cs
+++ b/src/Scriban.Tests/TestLexer.cs
@@ -552,11 +552,12 @@ namespace Scriban.Tests
                 {"&", TokenType.Amp},
                 {"&&", TokenType.DoubleAmp},
                 {"??", TokenType.DoubleQuestion},
+                {"?!", TokenType.QuestionExclamation},
                 {"||", TokenType.DoubleVerticalBar},
                 {"..", TokenType.DoubleDot},
                 {"..<", TokenType.DoubleDotLess},
             });
-            //{ "{", TokenType.OpenBrace}, // We cannot test them individualy here as they are used in the lexer to match braces and better handle closing code }}
+            //{ "{", TokenType.OpenBrace}, // We cannot test them individually here as they are used in the lexer to match braces and better handle closing code }}
             //{ "}", TokenType.CloseBrace},
         }
 

--- a/src/Scriban/Parsing/Lexer.cs
+++ b/src/Scriban/Parsing/Lexer.cs
@@ -806,6 +806,13 @@ namespace Scriban.Parsing
                         break;
                     }
 
+                    if (c == '!')
+                    {
+                        _token = new Token(TokenType.QuestionExclamation, start, _position);
+                        NextChar();
+                        break;
+                    }
+
                     _token = new Token(TokenType.Question, start, start);
                     break;
                 case '|':

--- a/src/Scriban/Parsing/Parser.Expressions.cs
+++ b/src/Scriban/Parsing/Parser.Expressions.cs
@@ -46,6 +46,7 @@ namespace Scriban.Parsing
                 case TokenType.DoubleLessThan: binaryOperator = ScriptBinaryOperator.ShiftLeft; break;
                 case TokenType.DoubleGreaterThan: binaryOperator = ScriptBinaryOperator.ShiftRight; break;
                 case TokenType.DoubleQuestion: binaryOperator = ScriptBinaryOperator.EmptyCoalescing; break;
+                case TokenType.QuestionExclamation: binaryOperator = ScriptBinaryOperator.NotEmptyCoalescing; break;
                 case TokenType.DoubleAmp: binaryOperator = ScriptBinaryOperator.And; break;
                 case TokenType.DoubleVerticalBar: binaryOperator = ScriptBinaryOperator.Or; break;
                 case TokenType.DoubleEqual: binaryOperator = ScriptBinaryOperator.CompareEqual; break;
@@ -1132,6 +1133,7 @@ namespace Scriban.Parsing
             switch (op)
             {
                 case ScriptBinaryOperator.EmptyCoalescing:
+                case ScriptBinaryOperator.NotEmptyCoalescing:
                     return 20;
                 case ScriptBinaryOperator.Or:
                     return 30;

--- a/src/Scriban/Parsing/TokenType.cs
+++ b/src/Scriban/Parsing/TokenType.cs
@@ -135,6 +135,9 @@ namespace Scriban.Parsing
         /// <summary>Token "?."</summary>
         QuestionDot,
 
+        /// <summary>Token "?!"</summary>
+        QuestionExclamation,
+
         /// <summary>Token "=="</summary>
         DoubleEqual,
 

--- a/src/Scriban/Parsing/TokenTypeExtensions.cs
+++ b/src/Scriban/Parsing/TokenTypeExtensions.cs
@@ -41,6 +41,7 @@ namespace Scriban.Parsing
                 TokenType.Question => "?",
                 TokenType.QuestionDot => "?.",
                 TokenType.DoubleQuestion => "??",
+                TokenType.QuestionExclamation => "?!",
                 TokenType.DoubleEqual => "==",
                 TokenType.ExclamationEqual => "!=",
                 TokenType.Less => "<",

--- a/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
@@ -138,6 +138,11 @@ namespace Scriban.Syntax
                 return leftValue ?? rightValue;
             }
 
+            if (op == ScriptBinaryOperator.NotEmptyCoalescing)
+            {
+                return leftValue != null ? rightValue : leftValue;
+            }
+
             switch (op)
             {
                 case ScriptBinaryOperator.LiquidHasKey:

--- a/src/Scriban/Syntax/Expressions/ScriptBinaryOperator.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptBinaryOperator.cs
@@ -21,6 +21,11 @@ namespace Scriban.Syntax
         /// </summary>
         EmptyCoalescing,
 
+        /// <summary>
+        /// The not empty coalescing operator ?!
+        /// </summary>
+        NotEmptyCoalescing,
+
         Or,
 
         And,
@@ -115,6 +120,8 @@ namespace Scriban.Syntax
                     return TokenType.DoubleVerticalBar;
                 case ScriptBinaryOperator.EmptyCoalescing:
                     return TokenType.DoubleQuestion;
+                case ScriptBinaryOperator.NotEmptyCoalescing:
+                    return TokenType.QuestionExclamation;
                 case ScriptBinaryOperator.ShiftLeft:
                     return TokenType.DoubleLessThan;
                 case ScriptBinaryOperator.ShiftRight:
@@ -170,6 +177,8 @@ namespace Scriban.Syntax
                     return "||";
                 case ScriptBinaryOperator.EmptyCoalescing:
                     return "??";
+                case ScriptBinaryOperator.NotEmptyCoalescing:
+                    return "?!";
                 case ScriptBinaryOperator.ShiftLeft:
                     return "<<";
                 case ScriptBinaryOperator.ShiftRight:

--- a/src/Scriban/Syntax/ScriptToken.cs
+++ b/src/Scriban/Syntax/ScriptToken.cs
@@ -31,6 +31,7 @@ namespace Scriban.Syntax
         public static ScriptToken Amp() => new ScriptToken(TokenType.Amp);
         public static ScriptToken Question() => new ScriptToken(TokenType.Question);
         public static ScriptToken DoubleQuestion() => new ScriptToken(TokenType.DoubleQuestion);
+        public static ScriptToken QuestionExclamation() => new ScriptToken(TokenType.QuestionExclamation);
         public static ScriptToken CompareEqual() => new ScriptToken(TokenType.DoubleEqual);
         public static ScriptToken CompareNotEqual() => new ScriptToken(TokenType.ExclamationEqual);
         public static ScriptToken CompareLess() => new ScriptToken(TokenType.Less);


### PR DESCRIPTION
In Scriban operators <code>||</code> and <code>&&</code> always return <code>boolean</code>. They behave as in normal strongly typed languages. But when working with string templates in jsx/react I found that JS like behaviour is very useful. Right now Scriban has equivalent of JS <code>||</code> in form of <code>??</code>. What I am proposing is adding complementary operator <code>?!</code> that would work as JS <code>&&</code>. 

```
a ?? b
where is defined as:
a != null ? a : b;
```

```
a ?! b
where is defined as:
a != null ? b : a;
```


