### PR TITLE
fix not detecting function call after pipe call when function does not have any arguments

### DIFF
--- a/src/Scriban/Parsing/Parser.Expressions.cs
+++ b/src/Scriban/Parsing/Parser.Expressions.cs
@@ -638,6 +638,15 @@ namespace Scriban.Parsing
                         break;
                     }
 
+                    if ((!_isScientific) && (leftOperand is ScriptVariableGlobal) && (parentNode is ScriptPipeCall) && (functionCall == null))
+                    {
+                        // only valid option for pipceCall.To is a function call, but when a function invocation does not have any arguments it is recognized as global variable here we fix that
+                        var funcCall = Open<ScriptFunctionCall>();
+                        funcCall.Target = leftOperand;
+                        funcCall.Span = leftOperand.Span;
+                        leftOperand = funcCall;
+                    }
+
                     if (
                             (_isScientific &&
                               Current.Type == TokenType.PipeGreater)

--- a/src/Scriban/Syntax/Expressions/ScriptFunctionCall.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptFunctionCall.cs
@@ -178,9 +178,18 @@ namespace Scriban.Syntax
             var scriptFunction = functionObject as ScriptFunction;
             var function = functionObject as IScriptCustomFunction;
 
+            var isPipeCall = processPipeArguments && context.CurrentPipeArguments != null && context.CurrentPipeArguments.Count > 0;
+
             if (function == null)
             {
-                throw new ScriptRuntimeException(callerContext.Span, $"Invalid target function `{functionObject}` ({context.GetTypeName(functionObject)})");
+                if ((isPipeCall) && (callerContext is ScriptFunctionCall funcCall))
+                {
+                    throw new ScriptRuntimeException(callerContext.Span, $"Pipe expression destination `{funcCall.Target}` is not a valid function ");
+                }
+                else
+                {
+                    throw new ScriptRuntimeException(callerContext.Span, $"Invalid target function `{functionObject}` ({context.GetTypeName(functionObject)})");
+                }
             }
 
             if (function.ParameterCount >= MaximumParameterCount)
@@ -201,7 +210,7 @@ namespace Scriban.Syntax
             List<ScriptExpression> allArgumentsWithPipe = null;
 
             // Handle pipe arguments here
-            if (processPipeArguments && context.CurrentPipeArguments != null && context.CurrentPipeArguments.Count > 0)
+            if (isPipeCall)
             {
                 var argCount = Math.Max(function.RequiredParameterCount, 1 + (arguments?.Count ?? 0));
                 allArgumentsWithPipe = context.GetOrCreateListOfScriptExpressions(argCount);

--- a/src/Scriban/Syntax/Expressions/ScriptPipeCall.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptPipeCall.cs
@@ -69,20 +69,13 @@ namespace Scriban.Syntax
 
                 return result;
             }
-            catch (ScriptRuntimeException sre) when (sre.OriginalMessage.StartsWith("Invalid target function"))
-            {
-                newPipe = false; 
-                context.ClearPipeArguments();
-                throw new ScriptRuntimeException(To.Span, $"Pipe expression destination `{To}` is not a valid function ");
-            }
             catch
             {
                 // If we have an exception clear all the pipe froms
                 newPipe = false; // Don't try to clear the pipe
-                context.ClearPipeArguments();                
+                context.ClearPipeArguments();
                 throw;
             }
-          
             finally
             {
                 if (newPipe)

--- a/src/Scriban/Syntax/Expressions/ScriptPipeCall.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptPipeCall.cs
@@ -69,13 +69,20 @@ namespace Scriban.Syntax
 
                 return result;
             }
+            catch (ScriptRuntimeException sre) when (sre.OriginalMessage.StartsWith("Invalid target function"))
+            {
+                newPipe = false; 
+                context.ClearPipeArguments();
+                throw new ScriptRuntimeException(To.Span, $"Pipe expression destination `{To}` is not a valid function ");
+            }
             catch
             {
                 // If we have an exception clear all the pipe froms
                 newPipe = false; // Don't try to clear the pipe
-                context.ClearPipeArguments();
+                context.ClearPipeArguments();                
                 throw;
             }
+          
             finally
             {
                 if (newPipe)


### PR DESCRIPTION
For the given template, when a function has some argument we get the correct AST:
```
{{ var | func 2 }} 
```
```
ScriptPage (0 - 20)
  ScriptBlockStatement (0 - 20)
    ScriptEscapeStatement (0 - 1)  [{{]
    ScriptExpressionStatement (3 - 14)
      ScriptPipeCall (3 - 14)
        ScriptVariableGlobal (3 - 5)  [var]
        ScriptToken (7 - 7)  [|]
        ScriptFunctionCall (9 - 14)
          ScriptVariableGlobal (9 - 12)  [func]
          ScriptLiteral (14 - 14)  [2]
    ScriptEscapeStatement (16 - 17)  [}}]
    ScriptRawStatement (18 - 20)
  ScriptBlockStatement END
```
but when a function does not have any arguments it is recognized as a global variable instead of as a function. 

```
{{ var | func }} 
```
```
ScriptPage (0 - 18)
  ScriptBlockStatement (0 - 18)
    ScriptEscapeStatement (0 - 1)  [{{]
    ScriptExpressionStatement (3 - 12)
      ScriptPipeCall (3 - 12)
        ScriptVariableGlobal (3 - 5)  [var]
        ScriptToken (7 - 7)  [|]
        ScriptVariableGlobal (9 - 12)  [func]
    ScriptEscapeStatement (14 - 15)  [}}]
    ScriptRawStatement (16 - 18)
  ScriptBlockStatement END
```

 Since after pipe operator, only valid node can be o type ScriptFunctionCall, this PR fixes that:

```
ScriptPage (0 - 18)
  ScriptBlockStatement (0 - 18)
    ScriptEscapeStatement (0 - 1)  [{{]
    ScriptExpressionStatement (3 - 12)
      ScriptPipeCall (3 - 12)
        ScriptVariableGlobal (3 - 5)  [var]
        ScriptToken (7 - 7)  [|]
        ScriptFunctionCall (9 - 12)
          ScriptVariableGlobal (9 - 12)  [func]
    ScriptEscapeStatement (14 - 15)  [}}]
    ScriptRawStatement (16 - 18)
  ScriptBlockStatement END
```

