### PR TITLE
Add support for ??= operator

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -896,11 +896,13 @@ The evaluated `left` and `right` expressions must resolve to an integer at runti
 | `left..right`   | Returns an iterator between `left` and `right` with a step of 1, including `right`. e.g: `1..5` iterates from 1 to 5
 | `left..<right`  | Returns an iterator between `left` and `right` with a step of 1, excluding `right`. e.g: `1..<5` iterates from 1 to 4
 
-### 8.8 The null-coalescing operators `??`, `?!` 
+### 8.8 The null-coalescing operators `??`, `?!`, `??=`  
 
 The operator `left ?? right` can be used to return the `right` value if `left` is null.
 
 The operator `left ?! right` can be used to return the `right` value if `left` is not null.
+
+The operator `left ??= right` can be used to set the `left` value to `right` if `left` is null.
 
 [:top:](#language)
 ### 8.9 Function call expression

--- a/doc/language.md
+++ b/doc/language.md
@@ -902,7 +902,7 @@ The operator `left ?? right` can be used to return the `right` value if `left` i
 
 The operator `left ?! right` can be used to return the `right` value if `left` is not null.
 
-The operator `left ??= right` can be used to set the `left` value to `right` if `left` is null.
+The operator `left ??= right` can be used to set the `right` value to `left` if `left` is null.
 
 [:top:](#language)
 ### 8.9 Function call expression

--- a/src/Scriban.Tests/TestFiles/100-expressions/141-null-coalescing-assignment.out.txt
+++ b/src/Scriban.Tests/TestFiles/100-expressions/141-null-coalescing-assignment.out.txt
@@ -1,0 +1,8 @@
+
+number: 5
+
+str: test
+plaintext: null ??= 10
+{a: 1, b: 2}
+str1
+0

--- a/src/Scriban.Tests/TestFiles/100-expressions/141-null-coalescing-assignment.txt
+++ b/src/Scriban.Tests/TestFiles/100-expressions/141-null-coalescing-assignment.txt
@@ -1,0 +1,11 @@
+{{ obj ??= {x: 5} }}
+number: {{ obj.x }}
+{{
+    obj2 = {a: "test"}
+    obj2 ??= {a: "test2"}
+}}
+str: {{ obj2.a }}
+plaintext: null ??= 10
+{{ obj3 ??= {a: 1, b: 2}; obj3; }}
+{{ str1 ??= "str1"; str1 }}
+{{ c ??= 6 - 6; c; }}

--- a/src/Scriban.Tests/TestLexer.cs
+++ b/src/Scriban.Tests/TestLexer.cs
@@ -552,6 +552,7 @@ namespace Scriban.Tests
                 {"&", TokenType.Amp},
                 {"&&", TokenType.DoubleAmp},
                 {"??", TokenType.DoubleQuestion},
+                {"??=", TokenType.DoubleQuestionEqual},
                 {"?!", TokenType.QuestionExclamation},
                 {"||", TokenType.DoubleVerticalBar},
                 {"..", TokenType.DoubleDot},

--- a/src/Scriban/Parsing/Lexer.cs
+++ b/src/Scriban/Parsing/Lexer.cs
@@ -842,7 +842,17 @@ namespace Scriban.Parsing
                     NextChar();
                     if (c == '?')
                     {
-                        _token = new Token(TokenType.DoubleQuestion, start, _position);
+                        var index = _position;
+                        NextChar();
+
+                        if (c == '=')
+                        {
+                            _token = new Token(TokenType.DoubleQuestionEqual, start, _position);
+                            NextChar();
+                            break;
+                        }
+
+                        _token = new Token(TokenType.DoubleQuestion, start, index);
                         NextChar();
                         break;
                     }

--- a/src/Scriban/Parsing/Parser.Expressions.cs
+++ b/src/Scriban/Parsing/Parser.Expressions.cs
@@ -46,6 +46,7 @@ namespace Scriban.Parsing
                 case TokenType.DoubleLessThan: binaryOperator = ScriptBinaryOperator.ShiftLeft; break;
                 case TokenType.DoubleGreaterThan: binaryOperator = ScriptBinaryOperator.ShiftRight; break;
                 case TokenType.DoubleQuestion: binaryOperator = ScriptBinaryOperator.EmptyCoalescing; break;
+                case TokenType.DoubleQuestionEqual: binaryOperator = ScriptBinaryOperator.EmptyCoalescingAssignment; break;
                 case TokenType.QuestionExclamation: binaryOperator = ScriptBinaryOperator.NotEmptyCoalescing; break;
                 case TokenType.DoubleAmp: binaryOperator = ScriptBinaryOperator.And; break;
                 case TokenType.DoubleVerticalBar: binaryOperator = ScriptBinaryOperator.Or; break;
@@ -1136,6 +1137,7 @@ namespace Scriban.Parsing
             {
                 TokenType.Equal => ScriptToken.Equal(),
                 TokenType.PlusEqual => ScriptToken.PlusEqual(),
+                TokenType.DoubleQuestionEqual => ScriptToken.DoubleQuestionEqual(),
                 TokenType.MinusEqual => ScriptToken.MinusEqual(),
                 TokenType.AsteriskEqual => ScriptToken.StarEqual(),
                 TokenType.DivideEqual => ScriptToken.DivideEqual(),
@@ -1221,6 +1223,7 @@ namespace Scriban.Parsing
             {
                 case ScriptBinaryOperator.EmptyCoalescing:
                 case ScriptBinaryOperator.NotEmptyCoalescing:
+                case ScriptBinaryOperator.EmptyCoalescingAssignment:
                     return 20;
                 case ScriptBinaryOperator.Or:
                     return 30;

--- a/src/Scriban/Parsing/TokenType.cs
+++ b/src/Scriban/Parsing/TokenType.cs
@@ -132,6 +132,9 @@ namespace Scriban.Parsing
         /// <summary>Token "??"</summary>
         DoubleQuestion,
 
+        /// <summary>Token "??="</summary>
+        DoubleQuestionEqual,
+
         /// <summary>Token "?."</summary>
         QuestionDot,
 

--- a/src/Scriban/Parsing/TokenTypeExtensions.cs
+++ b/src/Scriban/Parsing/TokenTypeExtensions.cs
@@ -42,6 +42,7 @@ namespace Scriban.Parsing
                 TokenType.QuestionDot => "?.",
                 TokenType.DoubleQuestion => "??",
                 TokenType.QuestionExclamation => "?!",
+                TokenType.DoubleQuestionEqual => "??=",
                 TokenType.DoubleEqual => "==",
                 TokenType.ExclamationEqual => "!=",
                 TokenType.Less => "<",

--- a/src/Scriban/Syntax/Expressions/ScriptAssignExpression.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptAssignExpression.cs
@@ -67,6 +67,7 @@ namespace Scriban.Syntax
                 TokenType.DivideEqual => ScriptBinaryOperator.Divide,
                 TokenType.DoubleDivideEqual => ScriptBinaryOperator.DivideRound,
                 TokenType.PercentEqual => ScriptBinaryOperator.Modulus,
+                TokenType.DoubleQuestionEqual => ScriptBinaryOperator.EmptyCoalescingAssignment,
                 _ => throw new ScriptRuntimeException(context.CurrentSpan, $"Operator {this.EqualToken} is not a valid compound assignment operator"),
             };
             return ScriptBinaryExpression.Evaluate(context, this.Span, op, left, right);

--- a/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
@@ -138,6 +138,12 @@ namespace Scriban.Syntax
                 return leftValue ?? rightValue;
             }
 
+            if (op == ScriptBinaryOperator.EmptyCoalescingAssignment)
+            {
+                leftValue ??= rightValue;
+                return leftValue;
+            }
+
             if (op == ScriptBinaryOperator.NotEmptyCoalescing)
             {
                 return leftValue != null ? rightValue : leftValue;

--- a/src/Scriban/Syntax/Expressions/ScriptBinaryOperator.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptBinaryOperator.cs
@@ -26,6 +26,11 @@ namespace Scriban.Syntax
         /// </summary>
         NotEmptyCoalescing,
 
+        /// <summary>
+        /// The empty coalescing assignment operator ??=
+        /// </summary>
+        EmptyCoalescingAssignment,
+
         Or,
 
         And,
@@ -128,7 +133,9 @@ namespace Scriban.Syntax
                 case ScriptBinaryOperator.EmptyCoalescing:
                     return TokenType.DoubleQuestion;
                 case ScriptBinaryOperator.NotEmptyCoalescing:
-                    return TokenType.QuestionExclamation;
+                    return TokenType.DoubleQuestion;
+                case ScriptBinaryOperator.EmptyCoalescingAssignment:
+                    return TokenType.DoubleQuestionEqual;
                 case ScriptBinaryOperator.ShiftLeft:
                     return TokenType.DoubleLessThan;
                 case ScriptBinaryOperator.ShiftRight:

--- a/src/Scriban/Syntax/ScriptToken.cs
+++ b/src/Scriban/Syntax/ScriptToken.cs
@@ -31,6 +31,7 @@ namespace Scriban.Syntax
         public static ScriptToken Amp() => new ScriptToken(TokenType.Amp);
         public static ScriptToken Question() => new ScriptToken(TokenType.Question);
         public static ScriptToken DoubleQuestion() => new ScriptToken(TokenType.DoubleQuestion);
+        public static ScriptToken DoubleQuestionEqual() => new ScriptToken(TokenType.DoubleQuestionEqual);
         public static ScriptToken QuestionExclamation() => new ScriptToken(TokenType.QuestionExclamation);
         public static ScriptToken CompareEqual() => new ScriptToken(TokenType.DoubleEqual);
         public static ScriptToken CompareNotEqual() => new ScriptToken(TokenType.ExclamationEqual);


### PR DESCRIPTION
This PR adds support for `??=` operator from C# 8. I've added test file 141 for this feature for easy read, I'd be happy to move it elsewhere to avoid creating more files.