### PR TITLE
Disable warning that appears when using Scriban in a source generator.

### DIFF
--- a/src/Scriban/Functions/HtmlFunctions.cs
+++ b/src/Scriban/Functions/HtmlFunctions.cs
@@ -108,7 +108,9 @@ namespace Scriban.Functions
             {
                 return text;
             }
+#pragma warning disable SYSLIB0013
             return Uri.EscapeUriString(text);
+#pragma warning restore SYSLIB0013
         }
     }
 }


### PR DESCRIPTION
When using Scriban in a source generator, the following warning is showing up in the build.
```
       "C:\projects\csharpier\Src\CSharpier.Generators\CSharpier.Generators.csproj" (rebuild target) (2:2) ->
         C:\Users\bela\.nuget\packages\scriban\4.0.1\src\Scriban\Functions\HtmlFunctions.cs(111,20): 
warning SYSLIB0013: 'Uri.EscapeUriString(string)' is obsolete:
'Uri.EscapeUriString can corrupt the Uri string in some cases.
Consider using Uri.EscapeDataString for query string components.'
```
`Uri.EscapeDataString` does not have the same behavior, so I assume changing to use it is not a solution. See https://docs.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0013 and https://github.com/dotnet/runtime/issues/31387 for some discussion of why it is being deprecated.
