### PR TITLE
fix accessing null?.property when EnableRelaxedMemberAccess == False

### DIFF
--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -749,7 +749,7 @@ Returns a datetime object of the current time, including the hour, minutes, seco
 ```
 > **output**
 ```html
-2021
+2022
 ```
 
 [:top:](#builtins)

--- a/src/Scriban.Tests/TestRuntime.cs
+++ b/src/Scriban.Tests/TestRuntime.cs
@@ -924,6 +924,9 @@ Tax: {{ 7 | match_tax }}";
                 var result = Template.Parse("{{a.property_a").Render(context);
                 Assert.AreEqual("A", result);
 
+                result = Template.Parse("{{null_ref?.property_a").Render(context);
+                Assert.AreEqual(string.Empty, result);
+
                 Assert.Catch<ScriptRuntimeException>(() =>
                    Template.Parse("{{a.property_a.null_ref}}").Render(context));
 

--- a/src/Scriban/Functions/DateTimeFunctions.cs
+++ b/src/Scriban/Functions/DateTimeFunctions.cs
@@ -127,7 +127,7 @@ namespace Scriban.Functions
         /// {{ date.now.year }}
         /// ```
         /// ```html
-        /// 2021
+        /// 2022
         /// ```
         /// </remarks>
         public static DateTime Now() => DateTime.Now;

--- a/src/Scriban/Syntax/Expressions/ScriptMemberExpression.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptMemberExpression.cs
@@ -118,7 +118,7 @@ namespace Scriban.Syntax
 
             if (targetObject == null)
             {
-                if (isSet || !context.EnableRelaxedMemberAccess)
+                if (isSet || (context.EnableRelaxedMemberAccess == false && DotToken.TokenType != TokenType.QuestionDot))
                 {
                     throw new ScriptRuntimeException(this.Member.Span, $"Object `{this.Target}` is null. Cannot access member: {this}"); // unit test: 131-member-accessor-error1.txt
                 }


### PR DESCRIPTION
When `TemplateContext.EnableRelaxedMemberAccess` is set to `false` this template fails:
```
{{
x = null     # x is null
x?.y          # x?.y will fail
}}
```
but it should not, since we use here `?.` and not `.`