### PR TITLE
Add extensions that extract FrontMatter as a Dictionary<string, string>

### DIFF
--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -417,8 +417,53 @@ variable + 1
             TextAssert.AreEqual("This is after the frontmatter: yes\n2", pageResult);
         }
 
+        [Test]
+        public void TestFrontMatterExtensions_WithAssignExpression()
+        {
+            var options = new LexerOptions { Mode = ScriptMode.FrontMatterAndContent };
+            var input = @"+++
+variable = 1
+name = 'yes'
++++
+TEMPLATE";
+            input = input.Replace("\r\n", "\n");
+            var template = ParseTemplate(input, options);
 
+            var dictionary = template.Page.FrontMatter.GetValues();
 
+            // Make sure the dictionary has 2 values
+            Assert.AreEqual(2, dictionary.Count);
+            // Make sure variable = "1"
+            Assert.True(dictionary.ContainsKey("variable"));
+            Assert.AreEqual("1", dictionary["variable"]);
+            // Make sure name = "yes"
+            Assert.True(dictionary.ContainsKey("name"));
+            Assert.AreEqual("yes", dictionary["name"]);
+        }
+
+        [Test]
+        public void TestFrontMatterExtensions_WithNamedArgument()
+        {
+            var options = new LexerOptions { Mode = ScriptMode.FrontMatterAndContent };
+            var input = @"+++
+variable: 1
+name: 'yes'
++++
+TEMPLATE";
+            input = input.Replace("\r\n", "\n");
+            var template = ParseTemplate(input, options);
+
+            var dictionary = template.Page.FrontMatter.GetValues();
+
+            // Make sure the dictionary has 2 values
+            Assert.AreEqual(2, dictionary.Count);
+            // Make sure variable = "1"
+            Assert.True(dictionary.ContainsKey("variable"));
+            Assert.AreEqual("1", dictionary["variable"]);
+            // Make sure name = "yes"
+            Assert.True(dictionary.ContainsKey("name"));
+            Assert.AreEqual("yes", dictionary["name"]);
+        }
 
         [Test]
         public void TestFrontMatterOnly()

--- a/src/Scriban/Syntax/ScriptFrontMatterExtensions.cs
+++ b/src/Scriban/Syntax/ScriptFrontMatterExtensions.cs
@@ -11,17 +11,13 @@ namespace Scriban.Syntax
     {
         public static Dictionary<string, string> GetValues(this ScriptFrontMatter frontMatter) =>
             frontMatter.Statements.Statements.Cast<ScriptExpressionStatement>()
-                       .Aggregate(new List<KeyValuePair<string, string>>(), (list, statement) =>
-                       {
-                           list.AddRange(statement.Expression switch
+                       .Aggregate(new Dictionary<string, string>(), (dictionary, statement) =>
+                           dictionary.Concat(statement.Expression switch
                            {
                                ScriptAssignExpression x => x.GetValues(),
                                ScriptNamedArgument x => x.GetValues(),
-                               _ => new Dictionary<string, string>()
-                           });
-                           return list;
-                       })
-                       .ToDictionary(x => x.Key, x => x.Value);
+                               _ => new Dictionary<string, string>(),
+                           }).ToDictionary(x => x.Key, x => x.Value));
 
         private static IEnumerable<KeyValuePair<string, string>> GetValues(this ScriptAssignExpression expression)
         {
@@ -33,8 +29,8 @@ namespace Scriban.Syntax
         private static IEnumerable<KeyValuePair<string, string>> GetValues(this ScriptNamedArgument expression)
         {
             var key = expression.Name.Name;
-            var value = ((ScriptLiteral)expression.Value).Value.ToString();
-            yield return new KeyValuePair<string, string>(key, value ?? string.Empty);
+            var value = ((ScriptLiteral)expression.Value).Value.ToString() ?? string.Empty;
+            yield return new KeyValuePair<string, string>(key, value);
         }
     }
 }

--- a/src/Scriban/Syntax/ScriptFrontMatterExtensions.cs
+++ b/src/Scriban/Syntax/ScriptFrontMatterExtensions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+namespace Scriban.Syntax
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class ScriptFrontMatterExtensions
+    {
+        public static Dictionary<string, string> GetValues(this ScriptFrontMatter frontMatter) =>
+            frontMatter.Statements.Statements.Cast<ScriptExpressionStatement>()
+                       .Aggregate(new List<KeyValuePair<string, string>>(), (list, statement) =>
+                       {
+                           list.AddRange(statement.Expression switch
+                           {
+                               ScriptAssignExpression x => x.GetValues(),
+                               ScriptNamedArgument x => x.GetValues(),
+                               _ => new Dictionary<string, string>()
+                           });
+                           return list;
+                       })
+                       .ToDictionary(x => x.Key, x => x.Value);
+
+        private static IEnumerable<KeyValuePair<string, string>> GetValues(this ScriptAssignExpression expression)
+        {
+            var key = ((ScriptVariable)expression.Target).Name;
+            var value = ((ScriptLiteral)expression.Value).Value.ToString() ?? string.Empty;
+            yield return new KeyValuePair<string, string>(key, value);
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> GetValues(this ScriptNamedArgument expression)
+        {
+            var key = expression.Name.Name;
+            var value = ((ScriptLiteral)expression.Value).Value.ToString();
+            yield return new KeyValuePair<string, string>(key, value ?? string.Empty);
+        }
+    }
+}


### PR DESCRIPTION
I had a need to access the front matter from a template so I wrote an extension. 😄

```text
+++
variable = 1
name = 'yes'
+++
TEMPLATE
```
```csharp
var options = new LexerOptions { Mode = ScriptMode.FrontMatterAndContent };
var template = Template.Parse(source, lexerOptions: options);
var values = template.Page.FrontMatter.GetValues(); // returns a Dictionary<string, string>
```

I added unit tests too. ✨