### PR TITLE
Fix a minor syntax error in the docs for case/when statements

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -1111,7 +1111,7 @@ This is the equivalent of `switch` statement in C#, a selection statement that c
     x = 5
     case x
       when 1, 2, 3
-          "Value is 1 or 2 or 3
+          "Value is 1 or 2 or 3"
       when 5
           "Value is 5"
       else


### PR DESCRIPTION
Fixes an (extremely small) syntax error in the language docs for case/when statements that caused me to go around in circles for quite a long time before I spotted it.