### PR TITLE
Implemented parsing option to enforce that an end-statement must match a block begin

### DIFF
--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -98,8 +98,9 @@ namespace Scriban.Tests
         {
             var template = Template.ParseLiquid("{%endunless");
             Assert.True(template.HasErrors);
-            Assert.AreEqual(1, template.Messages.Count);
+            Assert.AreEqual(2, template.Messages.Count);
             Assert.AreEqual("<input>(1,3) : error : Unable to find a pending `unless` for this `endunless`", template.Messages[0].ToString());
+            StringAssert.StartsWith("<input>(1,1) : error : Error while parsing ScriptPage: Found <end> statement `endScriptPage` without a corresponding beginning of a block", template.Messages[1].ToString());
         }
 
         [Test]
@@ -757,46 +758,16 @@ m
             Assert.Throws<ScriptRuntimeException>(() => template.Render(context));
         }
 
-        [TestCase(null, false)]
-        [TestCase(false, false)]
-        [TestCase(true, true)]
-        public void TestEnforceEndStatementMustMatchBlockBegin(bool? enforceOption, bool expectErrors)
+        [TestCase(@"ab{{end}}c")]  // no blocks
+        [TestCase(@"a{{if true}}b{{end}}{{end}}c")]  // one-level block
+        [TestCase(@"a{{if true}}{{for i in 0..1}}b{{end}}{{end}}{{end}}c")]  // two-level block (nested)
+        public void TestUnmatchedEndStatementCausesError(string templateText)
         {
-            // test three conditions of the new parser option:  default (not supplied), false, and true
-            ParserOptions? options = null;
-            if (enforceOption != null)
-            {
-                options = new ParserOptions() { EnforceEndStatementMustMatchBlockBegin = enforceOption.Value };
-            }
+            var template = Template.Parse(templateText);
+            Assert.True(template.HasErrors);
 
-            // variations on nesting levels, each with an unmatched end-statement
-            var inputsToTest = new[]
-            {
-                @"ab{{end}}c",  // no blocks
-                @"a{{if true}}b{{end}}{{end}}c",  // one-level block
-                @"a{{if true}}{{for i in 0..1}}b{{end}}{{end}}{{end}}c",  // two-level block (nested)
-            };
-
-            // test each variation
-            foreach(var input in inputsToTest)
-            {
-                var template = Template.Parse(input, parserOptions: options);
-                Assert.AreEqual(expectErrors, template.HasErrors);
-
-                if (expectErrors)
-                {
-                    Assert.AreEqual(1, template.Messages.Count);
-                    StringAssert.Contains("Found <end> statement without a corresponding beginning of a block", template.Messages[0].ToString());
-                }
-                else
-                {
-                    Assert.AreEqual(0, template.Messages.Count);
-
-                    // no errors expected, so now render and ensure the parsing stopped after the extra end-statement
-                    var result = template.Render();
-                    StringAssert.EndsWith("b", result);
-                }
-            }
+            Assert.AreEqual(1, template.Messages.Count);
+            StringAssert.Contains("Found <end> statement without a corresponding beginning of a block", template.Messages[0].ToString());
         }
 
         private static void TestFile(string inputName, bool testASTInstead = false)

--- a/src/Scriban/Parsing/Parser.Statements.cs
+++ b/src/Scriban/Parsing/Parser.Statements.cs
@@ -52,6 +52,18 @@ namespace Scriban.Parsing
 
                     if (hasEnd)
                     {
+                        if (_blockLevel == 1 && Options.EnforceEndStatementMustMatchBlockBegin)
+                        {
+                            if (_isLiquid)
+                            {
+                                var syntax = ScriptSyntaxAttribute.Get(parentStatement);
+                                LogError(parentStatement, parentStatement?.Span ?? CurrentSpan, $"Found <end> statement `end{syntax.TypeName}` without a corresponding beginning of a block");
+                            }
+                            else
+                            {
+                                LogError(parentStatement, GetSpanForToken(Previous), $"Found <end> statement without a corresponding beginning of a block");
+                            }
+                        }
                         break;
                     }
                 }

--- a/src/Scriban/Parsing/Parser.Statements.cs
+++ b/src/Scriban/Parsing/Parser.Statements.cs
@@ -52,7 +52,7 @@ namespace Scriban.Parsing
 
                     if (hasEnd)
                     {
-                        if (_blockLevel == 1 && Options.EnforceEndStatementMustMatchBlockBegin)
+                        if (_blockLevel == 1)
                         {
                             if (_isLiquid)
                             {

--- a/src/Scriban/Parsing/ParserOptions.cs
+++ b/src/Scriban/Parsing/ParserOptions.cs
@@ -29,5 +29,11 @@ namespace Scriban.Parsing
         /// If the number cannot be represented to a decimal, it will fall back to a double.
         /// </summary>
         public bool ParseFloatAsDecimal { get; set; }
+
+        /// <summary>
+        /// <c>true</c> to return a parse error if an end statement does not correspond to a block (e.g. if-end, while-end, etc.).
+        /// Default is <c>false</c>: an end statement that is not part of a block is allowed, but will prematurely end the parsing.
+        /// </summary>
+        public bool EnforceEndStatementMustMatchBlockBegin { get; set; }
     }
 }

--- a/src/Scriban/Parsing/ParserOptions.cs
+++ b/src/Scriban/Parsing/ParserOptions.cs
@@ -29,11 +29,5 @@ namespace Scriban.Parsing
         /// If the number cannot be represented to a decimal, it will fall back to a double.
         /// </summary>
         public bool ParseFloatAsDecimal { get; set; }
-
-        /// <summary>
-        /// <c>true</c> to return a parse error if an end statement does not correspond to a block (e.g. if-end, while-end, etc.).
-        /// Default is <c>false</c>: an end statement that is not part of a block is allowed, but will prematurely end the parsing.
-        /// </summary>
-        public bool EnforceEndStatementMustMatchBlockBegin { get; set; }
     }
 }


### PR DESCRIPTION
Adds a new ParserOption to log an error and end-statement occurs on blockLevel 1.  Related to issue #463. 