### PR TITLE
fix auto indent bug after ~}} block, add test

### DIFF
--- a/src/Scriban.Tests/TestParser.cs
+++ b/src/Scriban.Tests/TestParser.cs
@@ -589,6 +589,20 @@ Hello
             TextAssert.AreEqual("  test\n  test2", result);
         }
 
+        [Test]
+        public void TestIndent3()
+        {
+            var input = @"a
+{{~ if true ~}}
+b
+{{~ end ~}}
+ {{'c'}}";
+            var template = Template.Parse(input);
+            var result = template.Render();
+            result = TextAssert.Normalize(result);
+
+            TextAssert.AreEqual("a\nb\n c", result);
+        }
 
         [TestCaseSource("ListTestFiles", new object[] { "000-basic" })]
         public static void A000_basic(string inputName)

--- a/src/Scriban/TemplateContext.cs
+++ b/src/Scriban/TemplateContext.cs
@@ -763,7 +763,9 @@ namespace Scriban
                 }
                 else
                 {
-                    _previousTextWasNewLine = count > 0 && text[startIndex + count - 1] == '\n';
+                    if(count > 0){
+                        _previousTextWasNewLine = text[startIndex + count - 1] == '\n';
+                    }
                     Output.Write(text, startIndex, count);
                 }
             }

--- a/src/Scriban/TemplateContext.cs
+++ b/src/Scriban/TemplateContext.cs
@@ -763,6 +763,7 @@ namespace Scriban
                 }
                 else
                 {
+                    _previousTextWasNewLine = count > 0 && text[startIndex + count - 1] == '\n';
                     Output.Write(text, startIndex, count);
                 }
             }


### PR DESCRIPTION
Fixes issue #482 by resetting _previousTextWasNewLine to false when writing unindendented text.