### PR TITLE
[Fix] Examples to 'limit, offster and reversed'

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -1151,7 +1151,7 @@ Allows to start the iteration of the loop at the specified zero-based index:
 
 > **input**
 ```scriban-html
-{{~ for $i in 4..9 offset:2 ~}}
+{{~ for $i in 4..9 | array.offset:2 ~}}
  {{ $i }}
 {{~ end ~}}
 ```
@@ -1169,7 +1169,7 @@ Limits the iteration of the loop to a specified count:
 
 > **input**
 ```scriban-html
-{{~ for $i in 4..9 limit:2 ~}}
+{{~ for $i in 4..9 | array.limit:2 ~}}
  {{ $i }}
 {{~ end ~}}
 ```
@@ -1185,7 +1185,7 @@ Reverses the iteration of the elements:
 
 > **input**
 ```scriban-html
-{{~ for $i in 1..3 reversed ~}}
+{{~ for $i in 1..3 | array.reversed ~}}
  {{ $i }}
 {{~ end ~}}
 ```

--- a/doc/language.md
+++ b/doc/language.md
@@ -1151,7 +1151,7 @@ Allows to start the iteration of the loop at the specified zero-based index:
 
 > **input**
 ```scriban-html
-{{~ for $i in 4..9 | array.offset:2 ~}}
+{{~ for $i in (4..9) offset:2 ~}}
  {{ $i }}
 {{~ end ~}}
 ```
@@ -1169,7 +1169,7 @@ Limits the iteration of the loop to a specified count:
 
 > **input**
 ```scriban-html
-{{~ for $i in 4..9 | array.limit:2 ~}}
+{{~ for $i in (4..9) limit:2 ~}}
  {{ $i }}
 {{~ end ~}}
 ```
@@ -1185,7 +1185,7 @@ Reverses the iteration of the elements:
 
 > **input**
 ```scriban-html
-{{~ for $i in 1..3 | array.reversed ~}}
+{{~ for $i in (1..3) reversed ~}}
  {{ $i }}
 {{~ end ~}}
 ```


### PR DESCRIPTION
Fix on the documentation as the actual format seem to be a pipe leading to the array functions.


Example 1 (not working): 

```
{{ 
    for i in 1..5 reversed
        i
    end 
}}
```

This gives us: `error : Invalid target function '5' (int)`

Example 2 (what actually worked):
```
{{ 
    for i in 1..5 | array.reversed
        i
    end 
}}
```

This gives us: `5 4 3 2 1` as expected.

This is the same for the `limit` and the `offset` parameters.

Tried it over the playground and it checks out.

https://scribanonline.azurewebsites.net/