### PR TITLE
restore net6.0

### DIFF
--- a/src/Scriban/Scriban.props
+++ b/src/Scriban/Scriban.props
@@ -7,7 +7,7 @@
     <LangVersion>8.0</LangVersion>
     <DefineConstants>$(DefineConstants);SCRIBAN_PUBLIC</DefineConstants>
     <Authors>Alexandre Mutel</Authors>
-    <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>templating;handlebars;liquid</PackageTags>
     <PackageIcon>scriban.png</PackageIcon>
     <PackageReadmeFile>readme.md</PackageReadmeFile>


### PR DESCRIPTION
.NET 6.0 is still supported LTS version.
Please restore .NET 6.0 that was removed in 6c6d419d8cb89ed3a9b86f85da028faefeadc643