### PR TITLE
Add array.aggregate function

### DIFF
--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -20,6 +20,7 @@ Array functions available through the object 'array' in scriban.
 
 - [`array.add`](#arrayadd)
 - [`array.add_range`](#arrayadd_range)
+- [`array.aggregate`](#arrayaggregate)
 - [`array.compact`](#arraycompact)
 - [`array.concat`](#arrayconcat)
 - [`array.cycle`](#arraycycle)
@@ -99,6 +100,38 @@ The concatenation of the two input lists
 > **output**
 ```html
 [1, 2, 3, 4, 5]
+```
+
+[:top:](#builtins)
+### `array.aggregate`
+
+```
+array.aggregate <list> <seed> <function>
+```
+
+#### Description
+
+Applies an accumulator function on the list.
+
+#### Arguments
+
+- `list`: An input list
+- `seed`: The initial accumulator value
+- `function`: The function to apply to each item in the list
+
+#### Returns
+
+The transformed final accumulator value.
+
+#### Examples
+
+> **input**
+```scriban-html
+{{ [4, 5, 6, 7] | array.aggregate 5 @math.plus}}
+```
+> **output**
+```html
+27
 ```
 
 [:top:](#builtins)

--- a/src/Scriban.Tests/TestFiles/400-builtins/400-builtins.out.txt
+++ b/src/Scriban.Tests/TestFiles/400-builtins/400-builtins.out.txt
@@ -1,6 +1,7 @@
 List of all the builtin <array> functions:
  add
  add_range
+ aggregate
  compact
  concat
  contains

--- a/src/Scriban.Tests/TestRuntime.cs
+++ b/src/Scriban.Tests/TestRuntime.cs
@@ -558,6 +558,17 @@ end
         }
 
         [Test]
+        public void TestAggregate()
+        {
+            var template = Template.Parse(@"{{ ['Apple','Banana','Pear'] | array.aggregate 5 do
+ret $0 + ($1 | string.size)
+end
+}}");
+            var result = template.Render();
+            Assert.AreEqual("20", result);
+        }
+
+        [Test]
         public async Task TestAsyncAwait()
         {
             var text = @"{{ wait_and_see }}";


### PR DESCRIPTION
Fixes #532 

Instead of a reduce function, I implemented `array.aggregate`, that also accept an initial seed value. I could add more tests if you want to. Just point me to the applicable spot in the test suite where this would be required.

