### PR TITLE
Fix: If statement comparing string and null value results in object reference error

### DIFF
--- a/src/Scriban.Tests/TestFiles/100-expressions/110-binary-simple.out.txt
+++ b/src/Scriban.Tests/TestFiles/100-expressions/110-binary-simple.out.txt
@@ -52,3 +52,5 @@ null != null -> false
 null == 1 -> false
 1 != null -> true
 null != 1 -> true
+"a" == null -> false
+null == "b" -> false

--- a/src/Scriban.Tests/TestFiles/100-expressions/110-binary-simple.txt
+++ b/src/Scriban.Tests/TestFiles/100-expressions/110-binary-simple.txt
@@ -52,3 +52,5 @@ null != null -> {{ null != null }}
 null == 1 -> {{ null == 1 }}
 1 != null -> {{ 1 != null }}
 null != 1 -> {{ null != 1 }}
+"a" == null -> {{ "a" == null }}
+null == "b" -> {{ null == "b" }}

--- a/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
@@ -90,7 +90,7 @@ namespace Scriban.Syntax
                 default:
                 {
                     var rightValue = context.Evaluate(Right);
-                    return Evaluate(context, OperatorToken?.Span ?? Span, Operator, Left.Span, leftValue, Right.Span, rightValue);
+                    return Evaluate(context, OperatorToken?.Span ?? Span , Operator, Left.Span, leftValue, Right.Span, rightValue);
                 }
             }
         }
@@ -228,7 +228,7 @@ namespace Scriban.Syntax
                             return CalculateOthers(context, span, op, leftSpan, leftValue, rightSpan, rightValue);
                         }
                     }
-                    catch (Exception ex) when (!(ex is ScriptRuntimeException))
+                    catch (Exception ex) when(!(ex is ScriptRuntimeException))
                     {
                         throw new ScriptRuntimeException(span, ex.Message);
                     }
@@ -488,7 +488,7 @@ namespace Scriban.Syntax
                 switch (op)
                 {
                     case ScriptBinaryOperator.CompareEqual:
-                    return false;
+                        return false;
                     case ScriptBinaryOperator.CompareNotEqual:
                         return true;
 
@@ -872,9 +872,9 @@ namespace Scriban.Syntax
                     return Math.Round(left / right);
 
                 case ScriptBinaryOperator.ShiftLeft:
-                    return left * (decimal)Math.Pow(2, (double) right);
+                    return left * (decimal) Math.Pow(2, (double) right);
                 case ScriptBinaryOperator.ShiftRight:
-                    return left / (decimal)Math.Pow(2, (double) right);
+                    return left / (decimal) Math.Pow(2, (double) right);
 
                 case ScriptBinaryOperator.Power:
                     return (decimal)Math.Pow((double)left, (double)right);

--- a/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
@@ -488,7 +488,7 @@ namespace Scriban.Syntax
                 switch (op)
                 {
                     case ScriptBinaryOperator.CompareEqual:
-                    return false;
+                        return false;
                     case ScriptBinaryOperator.CompareNotEqual:
                         return true;
 

--- a/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
@@ -488,7 +488,7 @@ namespace Scriban.Syntax
                 switch (op)
                 {
                     case ScriptBinaryOperator.CompareEqual:
-                        return false;
+                    return false;
                     case ScriptBinaryOperator.CompareNotEqual:
                         return true;
 

--- a/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
@@ -71,27 +71,27 @@ namespace Scriban.Syntax
             switch (Operator)
             {
                 case ScriptBinaryOperator.And:
-                {
-                    var leftBoolValue = context.ToBool(Left.Span, leftValue);
-                    if (!leftBoolValue) return false;
-                    var rightValue = context.Evaluate(Right);
-                    var rightBoolValue = context.ToBool(Right.Span, rightValue);
-                    return leftBoolValue && rightBoolValue;
-                }
+                    {
+                        var leftBoolValue = context.ToBool(Left.Span, leftValue);
+                        if (!leftBoolValue) return false;
+                        var rightValue = context.Evaluate(Right);
+                        var rightBoolValue = context.ToBool(Right.Span, rightValue);
+                        return leftBoolValue && rightBoolValue;
+                    }
 
                 case ScriptBinaryOperator.Or:
-                {
-                    var leftBoolValue = context.ToBool(Left.Span, leftValue);
-                    if (leftBoolValue) return true;
-                    var rightValue = context.Evaluate(Right);
-                    return context.ToBool(Right.Span, rightValue);
-                }
+                    {
+                        var leftBoolValue = context.ToBool(Left.Span, leftValue);
+                        if (leftBoolValue) return true;
+                        var rightValue = context.Evaluate(Right);
+                        return context.ToBool(Right.Span, rightValue);
+                    }
 
                 default:
-                {
-                    var rightValue = context.Evaluate(Right);
-                    return Evaluate(context, OperatorToken?.Span ?? Span , Operator, Left.Span, leftValue, Right.Span, rightValue);
-                }
+                    {
+                        var rightValue = context.Evaluate(Right);
+                        return Evaluate(context, OperatorToken?.Span ?? Span, Operator, Left.Span, leftValue, Right.Span, rightValue);
+                    }
             }
         }
 
@@ -146,23 +146,23 @@ namespace Scriban.Syntax
             switch (op)
             {
                 case ScriptBinaryOperator.LiquidHasKey:
-                {
-                    var leftDict = leftValue as IDictionary<string, object>;
-                    if (leftDict != null)
                     {
-                        return ObjectFunctions.HasKey(leftDict, context.ObjectToString(rightValue));
+                        var leftDict = leftValue as IDictionary<string, object>;
+                        if (leftDict != null)
+                        {
+                            return ObjectFunctions.HasKey(leftDict, context.ObjectToString(rightValue));
+                        }
                     }
-                }
                     break;
 
                 case ScriptBinaryOperator.LiquidHasValue:
-                {
-                    var leftDict = leftValue as IDictionary<string, object>;
-                    if (leftDict != null)
                     {
-                        return ObjectFunctions.HasValue(leftDict, context.ObjectToString(rightValue));
+                        var leftDict = leftValue as IDictionary<string, object>;
+                        if (leftDict != null)
+                        {
+                            return ObjectFunctions.HasValue(leftDict, context.ObjectToString(rightValue));
+                        }
                     }
-                }
                     break;
 
                 case ScriptBinaryOperator.CompareEqual:
@@ -191,7 +191,11 @@ namespace Scriban.Syntax
                 case ScriptBinaryOperator.CloseInterpolated:
                     try
                     {
-                        if (leftValue is string || rightValue is string || leftValue is char || rightValue is char)
+                        if (leftValue == null || rightValue == null)
+                        {
+                            return CalculateOthers(context, span, op, leftSpan, leftValue, rightSpan, rightValue);
+                        }
+                        else if (leftValue is string || rightValue is string || leftValue is char || rightValue is char)
                         {
                             if (leftValue is char leftChar) leftValue = leftChar.ToString(context.CurrentCulture);
                             if (rightValue is char rightChar) rightValue = rightChar.ToString(CultureInfo.InvariantCulture);
@@ -224,7 +228,7 @@ namespace Scriban.Syntax
                             return CalculateOthers(context, span, op, leftSpan, leftValue, rightSpan, rightValue);
                         }
                     }
-                    catch (Exception ex) when(!(ex is ScriptRuntimeException))
+                    catch (Exception ex) when (!(ex is ScriptRuntimeException))
                     {
                         throw new ScriptRuntimeException(span, ex.Message);
                     }
@@ -484,7 +488,7 @@ namespace Scriban.Syntax
                 switch (op)
                 {
                     case ScriptBinaryOperator.CompareEqual:
-                    	return false;
+                        return false;
                     case ScriptBinaryOperator.CompareNotEqual:
                         return true;
 
@@ -868,9 +872,9 @@ namespace Scriban.Syntax
                     return Math.Round(left / right);
 
                 case ScriptBinaryOperator.ShiftLeft:
-                    return left * (decimal) Math.Pow(2, (double) right);
+                    return left * (decimal)Math.Pow(2, (double)right);
                 case ScriptBinaryOperator.ShiftRight:
-                    return left / (decimal) Math.Pow(2, (double) right);
+                    return left / (decimal)Math.Pow(2, (double)right);
 
                 case ScriptBinaryOperator.Power:
                     return (decimal)Math.Pow((double)left, (double)right);

--- a/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
+++ b/src/Scriban/Syntax/Expressions/ScriptBinaryExpression.cs
@@ -71,27 +71,27 @@ namespace Scriban.Syntax
             switch (Operator)
             {
                 case ScriptBinaryOperator.And:
-                    {
-                        var leftBoolValue = context.ToBool(Left.Span, leftValue);
-                        if (!leftBoolValue) return false;
-                        var rightValue = context.Evaluate(Right);
-                        var rightBoolValue = context.ToBool(Right.Span, rightValue);
-                        return leftBoolValue && rightBoolValue;
-                    }
+                {
+                    var leftBoolValue = context.ToBool(Left.Span, leftValue);
+                    if (!leftBoolValue) return false;
+                    var rightValue = context.Evaluate(Right);
+                    var rightBoolValue = context.ToBool(Right.Span, rightValue);
+                    return leftBoolValue && rightBoolValue;
+                }
 
                 case ScriptBinaryOperator.Or:
-                    {
-                        var leftBoolValue = context.ToBool(Left.Span, leftValue);
-                        if (leftBoolValue) return true;
-                        var rightValue = context.Evaluate(Right);
-                        return context.ToBool(Right.Span, rightValue);
-                    }
+                {
+                    var leftBoolValue = context.ToBool(Left.Span, leftValue);
+                    if (leftBoolValue) return true;
+                    var rightValue = context.Evaluate(Right);
+                    return context.ToBool(Right.Span, rightValue);
+                }
 
                 default:
-                    {
-                        var rightValue = context.Evaluate(Right);
-                        return Evaluate(context, OperatorToken?.Span ?? Span, Operator, Left.Span, leftValue, Right.Span, rightValue);
-                    }
+                {
+                    var rightValue = context.Evaluate(Right);
+                    return Evaluate(context, OperatorToken?.Span ?? Span, Operator, Left.Span, leftValue, Right.Span, rightValue);
+                }
             }
         }
 
@@ -146,23 +146,23 @@ namespace Scriban.Syntax
             switch (op)
             {
                 case ScriptBinaryOperator.LiquidHasKey:
+                {
+                    var leftDict = leftValue as IDictionary<string, object>;
+                    if (leftDict != null)
                     {
-                        var leftDict = leftValue as IDictionary<string, object>;
-                        if (leftDict != null)
-                        {
-                            return ObjectFunctions.HasKey(leftDict, context.ObjectToString(rightValue));
-                        }
+                        return ObjectFunctions.HasKey(leftDict, context.ObjectToString(rightValue));
                     }
+                }
                     break;
 
                 case ScriptBinaryOperator.LiquidHasValue:
+                {
+                    var leftDict = leftValue as IDictionary<string, object>;
+                    if (leftDict != null)
                     {
-                        var leftDict = leftValue as IDictionary<string, object>;
-                        if (leftDict != null)
-                        {
-                            return ObjectFunctions.HasValue(leftDict, context.ObjectToString(rightValue));
-                        }
+                        return ObjectFunctions.HasValue(leftDict, context.ObjectToString(rightValue));
                     }
+                }
                     break;
 
                 case ScriptBinaryOperator.CompareEqual:
@@ -488,7 +488,7 @@ namespace Scriban.Syntax
                 switch (op)
                 {
                     case ScriptBinaryOperator.CompareEqual:
-                        return false;
+                    return false;
                     case ScriptBinaryOperator.CompareNotEqual:
                         return true;
 
@@ -872,9 +872,9 @@ namespace Scriban.Syntax
                     return Math.Round(left / right);
 
                 case ScriptBinaryOperator.ShiftLeft:
-                    return left * (decimal)Math.Pow(2, (double)right);
+                    return left * (decimal)Math.Pow(2, (double) right);
                 case ScriptBinaryOperator.ShiftRight:
-                    return left / (decimal)Math.Pow(2, (double)right);
+                    return left / (decimal)Math.Pow(2, (double) right);
 
                 case ScriptBinaryOperator.Power:
                     return (decimal)Math.Pow((double)left, (double)right);


### PR DESCRIPTION
When comparing a null variable with a string, an error is thrown.  

For example:
```liquid
{% assign nothing = null %}
{% assign bar = 'foo' %}
{% if nothing > bar %}
  Not equal
{% endif %}
```

Produces `Object reference not set to an instance of an object.`

The conditional logic is checking for value of type `strings before it checks if a value is `null`.

It would make sense to check if values are `null` and run `CalculateOther(...)` if either left or right value is `null`.

If `null` and `null` can be compared without an error, `"a"` and `null` should also be able to be compared without an error.

This pull request adds a null check before determining the type of either value when comparing values in an if statement. 