### PR TITLE
Fix serializing DateTime with object.to_json

### DIFF
--- a/src/Scriban/Functions/ObjectFunctions.cs
+++ b/src/Scriban/Functions/ObjectFunctions.cs
@@ -515,6 +515,10 @@ namespace Scriban.Functions
                     }
                     writer.WriteEndArray();
                 }
+                else if (value is DateTime) {
+                    var valuestring = ((DateTime)value).ToString("O");
+                    JsonSerializer.Serialize(writer, valuestring, typeof(string));
+                }
                 else {
                     writer.WriteStartObject();
                     var accessor = context.GetMemberAccessor(value);


### PR DESCRIPTION
Serializing an object to a json with the object.to_json function will fail if the object contains a key with a DateTime object. During the serialization it tries to serialize all the properties of the DateTime object, but these include new DateTime objects which results in the error `CurrentDepth (1000) is equal to or larger than the maximum allowed depth of 1000. Cannot write the next JSON object or array.`.

This pr fixes it by forcing a DateTime value to be serialized as an ISO8601 string which is the unofficial standard notation for datetimes.
