### PR TITLE
feat: fix #555 Error object.to_json with date or timespan

### DIFF
--- a/src/Scriban.Tests/TestJsonSupport/TestTypeSerialization.cs
+++ b/src/Scriban.Tests/TestJsonSupport/TestTypeSerialization.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+using Newtonsoft.Json.Linq;
+using System;
+using System.Globalization;
+using System.Text.Json;
+
+namespace Scriban.Tests.TestJsonSupport;
+
+[TestFixture]
+public class TestTypeSerialization {
+    public static object[][] TestValues = [
+        [(DateTime) new DateTime(2024, 08, 07, 15, 27, 0), "\"2024-08-07T15:27:00\""],
+        [(TimeSpan) TimeSpan.FromTicks(123434563), "\"00:00:12.3434563\""],
+        [(DateOnly) DateOnly.FromDateTime(new DateTime(2024, 08, 07)), "\"2024-08-07\""],
+        [(DateTimeOffset) new DateTimeOffset(2024, 08, 07, 15, 27, 0, TimeSpan.FromHours(2)), "\"2024-08-07T15:27:00+02:00\""],
+        [(byte) 255, "255"],
+        [(char) 'R', "\"R\""],
+        [(decimal) 99.99m, "99.99"],
+        [(double) 99.99, "99.99"],
+        [(float) 99.99f, "99.99"],
+        [(Enum) StringSplitOptions.RemoveEmptyEntries, "1"],
+        [(Guid) Guid.Parse("82865716-6e99-4ba9-9a12-3e8b2e3cd891"), "\"82865716-6e99-4ba9-9a12-3e8b2e3cd891\""],
+        [(Uri) new Uri("/relative/url/?with=query", UriKind.Relative), "\"/relative/url/?with=query\""]
+    ];
+
+    [TestCaseSource(nameof(TestValues))]
+    public void Can_serialize_special_types_and_structs_to_json(object modelValue, string expected)
+    {
+        var template = Template.Parse("{{ model | object.to_json }}");
+
+        var model = new {
+            model = modelValue
+        };
+
+        var result = template.Render(model);
+
+        Console.WriteLine($"Result: {result}");
+        Assert.AreEqual(expected, result);
+    }
+
+    [Test]
+    public void JsonSerializer_produces_iso8601_with_trimmed_zeros()
+    {
+        var date = new DateTime(2024, 08, 07, 15, 27, 12, 234, DateTimeKind.Utc);
+
+        var iso8601Result = date.ToString("O");
+        Assert.AreEqual("2024-08-07T15:27:12.2340000Z", iso8601Result);
+
+        var jsonResult = JsonSerializer.Serialize(date);
+        Assert.AreEqual("\"2024-08-07T15:27:12.234Z\"", jsonResult);
+    }
+}

--- a/src/Scriban/Functions/ObjectFunctions.cs
+++ b/src/Scriban/Functions/ObjectFunctions.cs
@@ -502,7 +502,8 @@ namespace Scriban.Functions
                     value is null ||
                     value is string ||
                     value is bool ||
-                    type.IsPrimitiveOrDecimal()
+                    type.IsPrimitiveOrDecimal() ||
+                    value is IFormattable // handles types like System.DateTime and 99 more types. see: https://learn.microsoft.com/en-us/dotnet/api/system.iformattable?view=net-8.0
                 )
                 {
                     JsonSerializer.Serialize(writer, value, type);
@@ -514,10 +515,6 @@ namespace Scriban.Functions
                         WriteValue(context, writer, x);
                     }
                     writer.WriteEndArray();
-                }
-                else if (value is DateTime) {
-                    var valuestring = ((DateTime)value).ToString("O");
-                    JsonSerializer.Serialize(writer, valuestring, typeof(string));
                 }
                 else {
                     writer.WriteStartObject();


### PR DESCRIPTION
Add serialization support for all types deriving from IFormattable. All System types including time values like DateTime, TimeSpan, DateOnly and other special values like Uri, Guid, BigInteger, etc.. derive from IFormattable and are therefore compatible.

This PR improves, overwrites, and replaces PR-https://github.com/scriban/scriban/pull/558 
- The previous solution only handles/adds support for DateTime and fails to handle eg. TimeSpan, Guid, ...
- The current PR adds support for a wide range of types. [See All IFormattable Derived Types](https://learn.microsoft.com/en-us/dotnet/api/system.iformattable?view=net-8.0)

Breaking Changes

Both, the previous and the current PR use ISO8601 format for `DateTime` encoding.
So everything should work fine.
But the new PR slightly changes the actual ISO8601 representation.
eg. 

```c#
[Test]
public void JsonSerializer_produces_iso8601_with_trimmed_zeros()
{
    var date = new DateTime(2024, 08, 07, 15, 27, 12, 234, DateTimeKind.Utc);

    // old behavior:
    var iso8601Result = date.ToString("O");
    Assert.AreEqual("2024-08-07T15:27:12.2340000Z", iso8601Result);

    // new behavior: useless zeros are removed
    var jsonResult = JsonSerializer.Serialize(date);
    Assert.AreEqual("\"2024-08-07T15:27:12.234Z\"", jsonResult);
}
```

