### PR TITLE
Add array.select function

### DIFF
--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -38,6 +38,7 @@ Array functions available through the object 'array' in scriban.
 - [`array.sort`](#arraysort)
 - [`array.uniq`](#arrayuniq)
 - [`array.contains`](#arraycontains)
+- [`array.select`](#arrayselect)
 
 [:top:](#builtins)
 ### `array.add`
@@ -686,6 +687,38 @@ Returns if a `list` contains a specific `item`.
 ```html
 true
 ```
+
+[:top:](#builtins)
+### `array.select`
+
+```
+array.select <list> <function>
+```
+
+#### Description
+
+Projects each array item into a new object shape and returns the new array, according to the supplied function.
+
+#### Arguments
+
+- `list`: An input list
+- `function`: The function used to project each elemement of the list
+
+#### Returns
+
+Returns a new list which contains each item projected using the input function.
+
+#### Examples
+
+> **input**
+```scriban-html
+{{[{ a: 1 },{ a: 2 },{ a: 3 },] | array.select @(do; ret { new_prop: $0.a }; end)}}
+```
+> **output**
+```html
+[{new_prop: 1}, {new_prop: 2}, {new_prop: 3}]
+```
+
 [:top:](#builtins)
 
 ## `date` functions

--- a/src/Scriban.Tests/TestFiles/400-builtins/400-builtins.out.txt
+++ b/src/Scriban.Tests/TestFiles/400-builtins/400-builtins.out.txt
@@ -16,6 +16,7 @@ List of all the builtin <array> functions:
  offset
  remove_at
  reverse
+ select
  size
  sort
  uniq

--- a/src/Scriban.Tests/TestFiles/400-builtins/410-array.out.txt
+++ b/src/Scriban.Tests/TestFiles/400-builtins/410-array.out.txt
@@ -62,3 +62,4 @@ null | array.compact:
 products | array.sort "title" | array.map "title": ["Apple", "Banana", "Computer", "Mobile Phone", "Orange", "Sofa", "Table"]
 5 | array.sort: [5]
 [1, 2, 3] | array.join ", " @(do; ret $0 + "x"; end): "1", "2", "3"
+[{a: 1, b: 2},{a: 3,b: 4},{a:5, b:6}] | array.select @(@do; ret {a: $0.a, b: $0.b}; end): [{a: 1}, {a: 3}, {a: 5}]

--- a/src/Scriban.Tests/TestFiles/400-builtins/410-array.txt
+++ b/src/Scriban.Tests/TestFiles/400-builtins/410-array.txt
@@ -78,3 +78,4 @@ null | array.compact:{{ null | array.compact }}
 products | array.sort "title" | array.map "title": {{ products | array.sort "title" | array.map "title" | array.uniq }}
 5 | array.sort: {{ 5 | array.sort }}
 [1, 2, 3] | array.join ", " @(do; ret $0 + "x"; end): {{ [1, 2, 3] | array.join ", " @string.literal }}
+[{a: 1, b: 2},{a: 3, b: 4},{a:5, b:6}] | array.select @(@do; ret {a: $0.a, b: $0.b}; end): {{[{a: 1, b: 2},{a: 3,b: 4},{a:5,b:6}] | array.select @(@do; ret {a: $0.a }; end)}}

--- a/src/Scriban/Functions/ArrayFunctions.cs
+++ b/src/Scriban/Functions/ArrayFunctions.cs
@@ -531,6 +531,25 @@ namespace Scriban.Functions
             return ScriptRange.Reverse(list);
         }
 
+
+        public static IEnumerable Select(TemplateContext context, SourceSpan span, IEnumerable list, object function)
+        {
+            return ApplyFunction(context, span, list, function, SelectProcessor);
+        }
+        private static IEnumerable SelectInternal(TemplateContext context, ScriptNode callerContext, SourceSpan span, IEnumerable list, IScriptCustomFunction function, Type destType)
+        {
+            var arg = new ScriptArray(1);
+            foreach (var item in list)
+            {
+                var itemToTransform = context.ToObject(span, item, destType);
+                arg[0] = itemToTransform;
+                var itemTransformed = ScriptFunctionCall.Call(context, callerContext, function, arg);
+                yield return itemTransformed;
+            }
+        }
+
+        private static readonly ListProcessor SelectProcessor = SelectInternal;
+
         /// <summary>
         /// Returns the number of elements in the input `list`
         /// </summary>


### PR DESCRIPTION
Adds a new _array.select_ function, allowing projection of array items into a new form.

Usage included in docs, with added tests.

Solves for #165 