### PR TITLE
Fix DateTime and Object tests

### DIFF
--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -749,7 +749,7 @@ Returns a datetime object of the current time, including the hour, minutes, seco
 ```
 > **output**
 ```html
-2024
+2025
 ```
 
 [:top:](#builtins)

--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -2096,7 +2096,7 @@ A JSON representation of the value
 ```
 > **output**
 ```html
-{ "foo": "bar", "baz": [1, 2, 3] }
+{"foo":"bar","baz":[1,2,3]}
 true
 null
 ```

--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -2038,28 +2038,28 @@ A list with the member values of the input object
 ### `object.from_json`
 
 ```
-object.from_json <value>
+object.from_json <json>
 ```
 
 #### Description
 
-Converts a JSON string to a scriban value.
+Converts the json to a scriban value. Object, Array, string, etc.
 
 #### Arguments
 
-- `value`: The input JSON string.
+- `json`: The json to deserialize.
 
 #### Returns
 
-The scriban value.
+Returns the scriban value
 
 #### Examples
 
 > **input**
 ```scriban-html
 {{
-    obj = `{ "foo": 123 }` | object.from_json
-    obj.foo
+   obj = `{ "foo": 123 }` | object.from_json
+   obj.foo
 }}
 ```
 > **output**
@@ -2076,15 +2076,15 @@ object.to_json <value>
 
 #### Description
 
-Converts a scriban value to a JSON string.
+Converts the scriban value to JSON
 
 #### Arguments
 
-- `value`: The input value.
+- `value`: The input object.
 
 #### Returns
 
-A JSON representation of the value.
+A JSON representation of the value
 
 #### Examples
 
@@ -2096,11 +2096,10 @@ A JSON representation of the value.
 ```
 > **output**
 ```html
-{"foo":"bar","baz":[1,2,3]}
+{ "foo": "bar", "baz": [1, 2, 3] }
 true
 null
 ```
-
 [:top:](#builtins)
 
 ## `regex` functions

--- a/src/Scriban/Functions/DateTimeFunctions.cs
+++ b/src/Scriban/Functions/DateTimeFunctions.cs
@@ -128,7 +128,7 @@ namespace Scriban.Functions
         /// {{ date.now.year }}
         /// ```
         /// ```html
-        /// 2024
+        /// 2025
         /// ```
         /// </remarks>
         public static DateTime Now() => DateTime.Now;

--- a/src/Scriban/Functions/ObjectFunctions.cs
+++ b/src/Scriban/Functions/ObjectFunctions.cs
@@ -473,7 +473,7 @@ namespace Scriban.Functions
         /// {{ null | object.to_json }}
         /// ```
         /// ```html
-        /// { "foo": "bar", "baz": [1, 2, 3] }
+        /// {"foo":"bar","baz":[1,2,3]}
         /// true
         /// null
         /// ```


### PR DESCRIPTION
A Doc_date test failed because it validates the date.now.year.