### PR TITLE
Add `Try Out` link to builtins.md

### DIFF
--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -548,7 +548,7 @@ A new list with the element removed. If index is negative, remove at the end of 
 [4, 5, 7, 8]
 ```
 If the `index` is negative, removes at the end of the list (notice that we need to put -1 in parenthesis to avoid confusing the parser with a binary `-` operation):
-> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B4%2C%205%2C%206%2C%207%2C%208%5D%20%7C%20array.remove_at%202%20%7D%7D&model={})
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B4%2C%205%2C%206%2C%207%2C%208%5D%20%7C%20array.remove_at%20%28-1%29%20%7D%7D&model={})
 ```scriban-html
 {{ [4, 5, 6, 7, 8] | array.remove_at (-1) }}
 ```
@@ -649,7 +649,7 @@ Sorts by element's value:
 [2, 6, 10]
 ```
 Sorts by elements member's value:
-> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B10%2C%202%2C%206%5D%20%7C%20array.sort%20%7D%7D&model={})
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%0Aproducts%20%3D%20%5B%7Btitle%3A%20%22orange%22%2C%20type%3A%20%22fruit%22%7D%2C%20%7Btitle%3A%20%22computer%22%2C%20type%3A%20%22electronics%22%7D%2C%20%7Btitle%3A%20%22sofa%22%2C%20type%3A%20%22furniture%22%7D%5D%0Aproducts%20%7C%20array.sort%20%22title%22%20%7C%20array.map%20%22title%22%0A%7D%7D&model={})
 ```scriban-html
 {{
 products = [{title: "orange", type: "fruit"}, {title: "computer", type: "electronics"}, {title: "sofa", type: "furniture"}]

--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -62,7 +62,7 @@ A new list with the value added
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B1%2C%202%2C%203%5D%20%7C%20array.add%204%20%7D%7D&model={})
 ```scriban-html
 {{ [1, 2, 3] | array.add 4 }}
 ```
@@ -93,7 +93,7 @@ The concatenation of the two input lists
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B1%2C%202%2C%203%5D%20%7C%20array.add_range%20%5B4%2C%205%5D%20%7D%7D&model={})
 ```scriban-html
 {{ [1, 2, 3] | array.add_range [4, 5] }}
 ```
@@ -123,7 +123,7 @@ Returns a list with null value removed
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B1%2C%20null%2C%203%5D%20%7C%20array.compact%20%7D%7D&model={})
 ```scriban-html
 {{ [1, null, 3] | array.compact }}
 ```
@@ -154,7 +154,7 @@ The concatenation of the two input lists
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B1%2C%202%2C%203%5D%20%7C%20array.concat%20%5B4%2C%205%5D%20%7D%7D&model={})
 ```scriban-html
 {{ [1, 2, 3] | array.concat [4, 5] }}
 ```
@@ -185,7 +185,7 @@ Returns a list with null value removed
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20array.cycle%20%5B%27one%27%2C%20%27two%27%2C%20%27three%27%5D%20%7D%7D%0A%7B%7B%20array.cycle%20%5B%27one%27%2C%20%27two%27%2C%20%27three%27%5D%20%7D%7D%0A%7B%7B%20array.cycle%20%5B%27one%27%2C%20%27two%27%2C%20%27three%27%5D%20%7D%7D%0A%7B%7B%20array.cycle%20%5B%27one%27%2C%20%27two%27%2C%20%27three%27%5D%20%7D%7D&model={})
 ```scriban-html
 {{ array.cycle ['one', 'two', 'three'] }}
 {{ array.cycle ['one', 'two', 'three'] }}
@@ -225,7 +225,7 @@ A boolean indicating if one of the item in the list satisfied the function.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B%22%20hello%22%2C%20%22%20world%22%2C%20%2220%22%5D%20%7C%20array.any%20%40string.contains%20%2220%22%7D%7D%0A%7B%7B%20%5B%22%20hello%22%2C%20%22%20world%22%2C%20%2220%22%5D%20%7C%20array.any%20%40string.contains%20%2230%22%7D%7D&model={})
 ```scriban-html
 {{ [" hello", " world", "20"] | array.any @string.contains "20"}}
 {{ [" hello", " world", "20"] | array.any @string.contains "30"}}
@@ -258,7 +258,7 @@ Returns a list with each item being transformed by the function.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B%22%20a%22%2C%20%22%205%22%2C%20%226%20%22%5D%20%7C%20array.each%20%40string.strip%20%7D%7D&model={})
 ```scriban-html
 {{ [" a", " 5", "6 "] | array.each @string.strip }}
 ```
@@ -289,7 +289,7 @@ Returns a new list which contains only those elements which match the filter fun
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%5B%22%22%2C%20%22200%22%2C%20%22%22%2C%22400%22%5D%20%7C%20array.filter%20%40string.empty%7D%7D&model={})
 ```scriban-html
 {{["", "200", "","400"] | array.filter @string.empty}}
 ```
@@ -319,7 +319,7 @@ The first element of the input `list`.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B4%2C%205%2C%206%5D%20%7C%20array.first%20%7D%7D&model={})
 ```scriban-html
 {{ [4, 5, 6] | array.first }}
 ```
@@ -351,7 +351,7 @@ A new list with the element inserted.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B%22a%22%2C%20%22b%22%2C%20%22c%22%5D%20%7C%20array.insert_at%202%20%22Yo%22%20%7D%7D&model={})
 ```scriban-html
 {{ ["a", "b", "c"] | array.insert_at 2 "Yo" }}
 ```
@@ -383,7 +383,7 @@ A new list with the element inserted.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B1%2C%202%2C%203%5D%20%7C%20array.join%20%22%7C%22%20%7D%7D&model={})
 ```scriban-html
 {{ [1, 2, 3] | array.join "|" }}
 ```
@@ -413,7 +413,7 @@ The last element of the input `list`.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B4%2C%205%2C%206%5D%20%7C%20array.last%20%7D%7D&model={})
 ```scriban-html
 {{ [4, 5, 6] | array.last }}
 ```
@@ -444,7 +444,7 @@ Returns a limited number of elments from the input list
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B4%2C%205%2C%206%5D%20%7C%20array.limit%202%20%7D%7D&model={})
 ```scriban-html
 {{ [4, 5, 6] | array.limit 2 }}
 ```
@@ -475,7 +475,7 @@ Accepts an array element's attribute as a parameter and creates an array out of 
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%0Aproducts%20%3D%20%5B%7Btitle%3A%20%22orange%22%2C%20type%3A%20%22fruit%22%7D%2C%20%7Btitle%3A%20%22computer%22%2C%20type%3A%20%22electronics%22%7D%2C%20%7Btitle%3A%20%22sofa%22%2C%20type%3A%20%22furniture%22%7D%5D%0Aproducts%20%7C%20array.map%20%22type%22%20%7C%20array.uniq%20%7C%20array.sort%20%7D%7D&model={})
 ```scriban-html
 {{
 products = [{title: "orange", type: "fruit"}, {title: "computer", type: "electronics"}, {title: "sofa", type: "furniture"}]
@@ -508,7 +508,7 @@ Returns the remaining of the list after the specified offset
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B4%2C%205%2C%206%2C%207%2C%208%5D%20%7C%20array.offset%202%20%7D%7D&model={})
 ```scriban-html
 {{ [4, 5, 6, 7, 8] | array.offset 2 }}
 ```
@@ -539,7 +539,7 @@ A new list with the element removed. If index is negative, remove at the end of 
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B4%2C%205%2C%206%2C%207%2C%208%5D%20%7C%20array.remove_at%202%20%7D%7D&model={})
 ```scriban-html
 {{ [4, 5, 6, 7, 8] | array.remove_at 2 }}
 ```
@@ -548,7 +548,7 @@ A new list with the element removed. If index is negative, remove at the end of 
 [4, 5, 7, 8]
 ```
 If the `index` is negative, removes at the end of the list (notice that we need to put -1 in parenthesis to avoid confusing the parser with a binary `-` operation):
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B4%2C%205%2C%206%2C%207%2C%208%5D%20%7C%20array.remove_at%202%20%7D%7D&model={})
 ```scriban-html
 {{ [4, 5, 6, 7, 8] | array.remove_at (-1) }}
 ```
@@ -578,7 +578,7 @@ A new list in reversed order.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B4%2C%205%2C%206%2C%207%5D%20%7C%20array.reverse%20%7D%7D&model={})
 ```scriban-html
 {{ [4, 5, 6, 7] | array.reverse }}
 ```
@@ -608,7 +608,7 @@ A number of elements in the input `list`.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B4%2C%205%2C%206%5D%20%7C%20array.size%20%7D%7D&model={})
 ```scriban-html
 {{ [4, 5, 6] | array.size }}
 ```
@@ -640,7 +640,7 @@ A list sorted according to the value of each element or the value of the specifi
 #### Examples
 
 Sorts by element's value:
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B10%2C%202%2C%206%5D%20%7C%20array.sort%20%7D%7D&model={})
 ```scriban-html
 {{ [10, 2, 6] | array.sort }}
 ```
@@ -649,7 +649,7 @@ Sorts by element's value:
 [2, 6, 10]
 ```
 Sorts by elements member's value:
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B10%2C%202%2C%206%5D%20%7C%20array.sort%20%7D%7D&model={})
 ```scriban-html
 {{
 products = [{title: "orange", type: "fruit"}, {title: "computer", type: "electronics"}, {title: "sofa", type: "furniture"}]
@@ -682,7 +682,7 @@ A list of unique elements of the input `list`.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B1%2C%201%2C%204%2C%205%2C%208%2C%208%5D%20%7C%20array.uniq%20%7D%7D&model={})
 ```scriban-html
 {{ [1, 1, 4, 5, 8, 8] | array.uniq }}
 ```
@@ -713,7 +713,7 @@ Returns if a `list` contains a specific `item`.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B1%2C%202%2C%203%2C%204%5D%20%7C%20array.contains%204%20%7D%7D&model={})
 ```scriban-html
 {{ [1, 2, 3, 4] | array.contains 4 }}
 ```
@@ -778,7 +778,7 @@ Returns a datetime object of the current time, including the hour, minutes, seco
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20date.now.year%20%7D%7D&model={})
 ```scriban-html
 {{ date.now.year }}
 ```
@@ -809,7 +809,7 @@ A new date
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20date.parse%20%272016%2F01%2F05%27%20%7C%20date.add_days%201%20%7D%7D&model={})
 ```scriban-html
 {{ date.parse '2016/01/05' | date.add_days 1 }}
 ```
@@ -840,7 +840,7 @@ A new date
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20date.parse%20%272016%2F01%2F05%27%20%7C%20date.add_months%201%20%7D%7D&model={})
 ```scriban-html
 {{ date.parse '2016/01/05' | date.add_months 1 }}
 ```
@@ -871,7 +871,7 @@ A new date
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20date.parse%20%272016%2F01%2F05%27%20%7C%20date.add_years%201%20%7D%7D&model={})
 ```scriban-html
 {{ date.parse '2016/01/05' | date.add_years 1 }}
 ```
@@ -999,7 +999,7 @@ A date object
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20date.parse%20%272016%2F01%2F05%27%20%7D%7D%0A%7B%7B%20date.parse%20%272018--06--17%27%20%27%25Y--%25m--%25d%27%20%7D%7D%0A%7B%7B%20date.parse%20%272021%2F11%2F30%2020%3A50%3A23Z%27%20%7D%7D%0A%7B%7B%20date.parse%20%2720%2F01%2F2022%2008%3A32%3A48%20%2B00%3A00%27%20culture%3A%27en-GB%27%20%7D%7D&model={})
 ```scriban-html
 {{ date.parse '2016/01/05' }}
 {{ date.parse '2018--06--17' '%Y--%m--%d' }}
@@ -1084,7 +1084,7 @@ Suppose that `date.now` would return the date `2013-09-12 22:49:27 +0530`, the f
 | `"%%"` |  `"%"`            | Output the character `%`
 
 Note that the format is using a good part of the ruby format ([source](http://apidock.com/ruby/DateTime/strftime))
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20date.parse%20%272016%2F01%2F05%27%20%7C%20date.to_string%20%27%25d%20%25b%20%25Y%27%20%7D%7D%0A%7B%7B%20date.parse%20%272016%2F01%2F05%27%20%7C%20date.to_string%20%27%25d%20%25B%20%25Y%27%20%27fr-FR%27%20%7D%7D&model={})
 ```scriban-html
 {{ date.parse '2016/01/05' | date.to_string '%d %b %Y' }}
 {{ date.parse '2016/01/05' | date.to_string '%d %B %Y' 'fr-FR' }}
@@ -1144,7 +1144,7 @@ Notice that the implementation of this function is using a simple regex, so it c
 If you are looking for a secure HTML stripped, you might want to plug your own HTML function by using [AngleSharp](https://github.com/AngleSharp/AngleSharp) to
 strip these HTML tags.
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22%3Cp%3EThis%20is%20a%20paragraph%3C%2Fp%3E%22%20%7C%20html.strip%20%7D%7D&model={})
 ```scriban-html
 {{ "<p>This is a paragraph</p>" | html.strip }}
 ```
@@ -1174,7 +1174,7 @@ The input string removed with any HTML tags
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22%3Cp%3EThis%20is%20a%20paragraph%3C%2Fp%3E%22%20%7C%20html.escape%20%7D%7D&model={})
 ```scriban-html
 {{ "<p>This is a paragraph</p>" | html.escape }}
 ```
@@ -1204,7 +1204,7 @@ The input string url encoded
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22john%40liquid.com%22%20%7C%20html.url_encode%20%7D%7D&model={})
 ```scriban-html
 {{ "john@liquid.com" | html.url_encode }}
 ```
@@ -1234,7 +1234,7 @@ The input string url escaped
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22%3Chello%3E%20%26%20%3Cscriban%3E%22%20%7C%20html.url_escape%20%7D%7D&model={})
 ```scriban-html
 {{ "<hello> & <scriban>" | html.url_escape }}
 ```
@@ -1283,7 +1283,7 @@ The absolute value of the input value
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20-15.5%7C%20math.abs%20%7D%7D%0A%7B%7B%20-5%7C%20math.abs%20%7D%7D&model={})
 ```scriban-html
 {{ -15.5| math.abs }}
 {{ -5| math.abs }}
@@ -1315,7 +1315,7 @@ The smallest integer greater than or equal to the specified number.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%204.6%20%7C%20math.ceil%20%7D%7D%0A%7B%7B%204.3%20%7C%20math.ceil%20%7D%7D&model={})
 ```scriban-html
 {{ 4.6 | math.ceil }}
 {{ 4.3 | math.ceil }}
@@ -1349,7 +1349,7 @@ The division of `value` by `divisor`.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%208.4%20%7C%20math.divided_by%202.0%20%7C%20math.round%201%20%7D%7D%0A%7B%7B%208.4%20%7C%20math.divided_by%202%20%7D%7D&model={})
 ```scriban-html
 {{ 8.4 | math.divided_by 2.0 | math.round 1 }}
 {{ 8.4 | math.divided_by 2 }}
@@ -1381,7 +1381,7 @@ The largest integer less than or equal to the specified number.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%204.6%20%7C%20math.floor%20%7D%7D%0A%7B%7B%204.3%20%7C%20math.floor%20%7D%7D&model={})
 ```scriban-html
 {{ 4.6 | math.floor }}
 {{ 4.3 | math.floor }}
@@ -1415,7 +1415,7 @@ The largest integer less than or equal to the specified number.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20255%20%7C%20math.format%20%22X4%22%20%7D%7D&model={})
 ```scriban-html
 {{ 255 | math.format "X4" }}
 ```
@@ -1445,7 +1445,7 @@ Returns a boolean indicating if the input value is a number
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20255%20%7C%20math.is_number%20%7D%7D%0A%7B%7B%20%22yo%22%20%7C%20math.is_number%20%7D%7D&model={})
 ```scriban-html
 {{ 255 | math.is_number }}
 {{ "yo" | math.is_number }}
@@ -1478,7 +1478,7 @@ The results of the subtraction: `value` - `with`
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20255%20%7C%20math.minus%205%7D%7D&model={})
 ```scriban-html
 {{ 255 | math.minus 5}}
 ```
@@ -1509,7 +1509,7 @@ The results of the modulo: `value` % `with`
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%2011%20%7C%20math.modulo%2010%7D%7D&model={})
 ```scriban-html
 {{ 11 | math.modulo 10}}
 ```
@@ -1540,7 +1540,7 @@ The results of the addition: `value` + `with`
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%201%20%7C%20math.plus%202%7D%7D&model={})
 ```scriban-html
 {{ 1 | math.plus 2}}
 ```
@@ -1571,7 +1571,7 @@ A value rounded to the nearest integer or to the specified number of fractional 
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%204.6%20%7C%20math.round%20%7D%7D%0A%7B%7B%204.3%20%7C%20math.round%20%7D%7D%0A%7B%7B%204.5612%20%7C%20math.round%202%20%7D%7D&model={})
 ```scriban-html
 {{ 4.6 | math.round }}
 {{ 4.3 | math.round }}
@@ -1606,7 +1606,7 @@ The results of the multiplication: `value` * `with`
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%202%20%7C%20math.times%203%7D%7D&model={})
 ```scriban-html
 {{ 2 | math.times 3}}
 ```
@@ -1635,7 +1635,7 @@ The created UUID, ex. 2dc55d50-3f6c-446a-87d0-a5a4eed23269
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20math.uuid%20%7D%7D&model={})
 ```scriban-html
 {{ math.uuid }}
 ```
@@ -1666,7 +1666,7 @@ A random number greater or equal to minValue and less than maxValue
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20math.random%201%2010%20%7D%7D&model={})
 ```scriban-html
 {{ math.random 1 10 }}
 ```
@@ -1716,7 +1716,7 @@ The `default` value is returned if the input `value` is null or an empty string 
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20undefined_var%20%7C%20object.default%20%22Yo%22%20%7D%7D&model={})
 ```scriban-html
 {{ undefined_var | object.default "Yo" }}
 ```
@@ -1746,7 +1746,7 @@ The evaluation of the input value.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%221%20%2B%202%22%20%7C%20object.eval%20%7D%7D&model={})
 ```scriban-html
 {{ "1 + 2" | object.eval }}
 ```
@@ -1776,7 +1776,7 @@ The evaluation of the input value.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22This%20is%20a%20template%20text%20%7B%7B%201%20%2B%202%20%7D%7D%22%20%7C%20object.eval_template%20%7D%7D&model={})
 ```scriban-html
 {{ "This is a template text {{ 1 + 2 }}" | object.eval_template }}
 ```
@@ -1808,7 +1808,7 @@ Formats an object using specified format.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20255%20%7C%20object.format%20%22X4%22%20%7D%7D%0A%7B%7B%201523%20%7C%20object.format%20%22N2%22%20%22en-US%22%20%7D%7D&model={})
 ```scriban-html
 {{ 255 | object.format "X4" }}
 {{ 1523 | object.format "N2" "en-US" }}
@@ -1841,7 +1841,7 @@ Checks if the specified object as the member `key`
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20product%20%7C%20object.has_key%20%22title%22%20%7D%7D&model={})
 ```scriban-html
 {{ product | object.has_key "title" }}
 ```
@@ -1872,7 +1872,7 @@ Checks if the specified object as a value for the member `key`
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20product%20%7C%20object.has_value%20%22title%22%20%7D%7D&model={})
 ```scriban-html
 {{ product | object.has_value "title" }}
 ```
@@ -1902,7 +1902,7 @@ A list with the member names/key of the input object
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20product%20%7C%20object.keys%20%7C%20array.sort%20%7D%7D&model={})
 ```scriban-html
 {{ product | object.keys | array.sort }}
 ```
@@ -1935,7 +1935,7 @@ The size of the input object.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%5B1%2C%202%2C%203%5D%20%7C%20object.size%20%7D%7D&model={})
 ```scriban-html
 {{ [1, 2, 3] | object.size }}
 ```
@@ -1965,7 +1965,7 @@ Returns string representing the type of the input object. The type can be `strin
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20null%20%7C%20object.typeof%20%7D%7D%0A%7B%7B%20true%20%7C%20object.typeof%20%7D%7D%0A%7B%7B%201%20%7C%20object.typeof%20%7D%7D%0A%7B%7B%201.0%20%7C%20object.typeof%20%7D%7D%0A%7B%7B%20%22text%22%20%7C%20object.typeof%20%7D%7D%0A%7B%7B%201..5%20%7C%20object.typeof%20%7D%7D%0A%7B%7B%20%5B1%2C2%2C3%2C4%2C5%5D%20%7C%20object.typeof%20%7D%7D%0A%7B%7B%20%7B%7D%20%7C%20object.typeof%20%7D%7D%0A%7B%7B%20object%20%7C%20object.typeof%20%7D%7D&model={})
 ```scriban-html
 {{ null | object.typeof }}
 {{ true | object.typeof }}
@@ -2014,7 +2014,7 @@ Returns string representing the type of the input object. The type can be `strin
 
 This function is newer than object.typeof and returns more detailed results about the types (e.g instead of `number`, returns `int` or `double`)
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20null%20%7C%20object.kind%20%7D%7D%0A%7B%7B%20true%20%7C%20object.kind%20%7D%7D%0A%7B%7B%201%20%7C%20object.kind%20%7D%7D%0A%7B%7B%201.0%20%7C%20object.kind%20%7D%7D%0A%7B%7B%20%22text%22%20%7C%20object.kind%20%7D%7D%0A%7B%7B%201..5%20%7C%20object.kind%20%7D%7D%0A%7B%7B%20%5B1%2C2%2C3%2C4%2C5%5D%20%7C%20object.kind%20%7D%7D%0A%7B%7B%20%7B%7D%20%7C%20object.kind%20%7D%7D%0A%7B%7B%20object%20%7C%20object.kind%20%7D%7D&model={})
 ```scriban-html
 {{ null | object.kind }}
 {{ true | object.kind }}
@@ -2060,7 +2060,7 @@ A list with the member values of the input object
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20product%20%7C%20object.values%20%7C%20array.sort%20%7D%7D&model={})
 ```scriban-html
 {{ product | object.values | array.sort }}
 ```
@@ -2090,7 +2090,7 @@ Returns the scriban value
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%0A%20%20%20obj%20%3D%20%60%7B%20%22foo%22%3A%20123%20%7D%60%20%7C%20object.from_json%0A%20%20%20obj.foo%0A%7D%7D&model={})
 ```scriban-html
 {{
    obj = `{ "foo": 123 }` | object.from_json
@@ -2123,7 +2123,7 @@ A JSON representation of the value
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%7B%20foo%3A%20%22bar%22%2C%20baz%3A%20%5B1%2C%202%2C%203%5D%20%7D%20%7C%20object.to_json%20%7D%7D%0A%7B%7B%20true%20%7C%20object.to_json%20%7D%7D%0A%7B%7B%20null%20%7C%20object.to_json%20%7D%7D&model={})
 ```scriban-html
 {{ { foo: "bar", baz: [1, 2, 3] } | object.to_json }}
 {{ true | object.to_json }}
@@ -2175,7 +2175,7 @@ A string of characters with metacharacters converted to their escaped form.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22%28abc.%2A%29%22%20%7C%20regex.escape%20%7D%7D&model={})
 ```scriban-html
 {{ "(abc.*)" | regex.escape }}
 ```
@@ -2211,7 +2211,7 @@ An array that contains all the match groups. The first group contains the entire
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22this%20is%20a%20text123%22%20%7C%20regex.match%20%60%28%5Cw%2B%29%20a%20%28%5Ba-z%5D%2B%5Cd%2B%29%60%20%7D%7D&model={})
 ```scriban-html
 {{ "this is a text123" | regex.match `(\w+) a ([a-z]+\d+)` }}
 ```
@@ -2248,7 +2248,7 @@ An array of matches that contains all the match groups. The first group contains
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22this%20is%20a%20text123%22%20%7C%20regex.matches%20%60%28%5Cw%2B%29%60%20%7D%7D&model={})
 ```scriban-html
 {{ "this is a text123" | regex.matches `(\w+)` }}
 ```
@@ -2286,7 +2286,7 @@ A new string that is identical to the input string, except that the replacement 
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22abbbbcccd%22%20%7C%20regex.replace%20%22b%2Bc%2B%22%20%22-Yo-%22%20%7D%7D&model={})
 ```scriban-html
 {{ "abbbbcccd" | regex.replace "b+c+" "-Yo-" }}
 ```
@@ -2322,7 +2322,7 @@ A string array.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22a%2C%20b%20%20%20%2C%20c%2C%20%20%20%20d%22%20%7C%20regex.split%20%60%5Cs%2A%2C%5Cs%2A%60%20%7D%7D&model={})
 ```scriban-html
 {{ "a, b   , c,    d" | regex.split `\s*,\s*` }}
 ```
@@ -2352,7 +2352,7 @@ A string of characters with any escaped characters converted to their unescaped 
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22%5C%5C%28abc%5C%5C.%5C%5C%2A%5C%5C%29%22%20%7C%20regex.unescape%20%7D%7D&model={})
 ```scriban-html
 {{ "\\(abc\\.\\*\\)" | regex.unescape }}
 ```
@@ -2433,7 +2433,7 @@ The two strings concatenated
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22Hel%5Ctlo%5Cn%5C%22W%5C%5Corld%22%20%7C%20string.escape%20%7D%7D&model={})
 ```scriban-html
 {{ "Hel\tlo\n\"W\\orld" | string.escape }}
 ```
@@ -2464,7 +2464,7 @@ The two strings concatenated
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22Hello%22%20%7C%20string.append%20%22%20World%22%20%7D%7D&model={})
 ```scriban-html
 {{ "Hello" | string.append " World" }}
 ```
@@ -2494,7 +2494,7 @@ The capitalized input string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22test%22%20%7C%20string.capitalize%20%7D%7D&model={})
 ```scriban-html
 {{ "test" | string.capitalize }}
 ```
@@ -2524,7 +2524,7 @@ The capitalized input string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22This%20is%20easy%22%20%7C%20string.capitalizewords%20%7D%7D&model={})
 ```scriban-html
 {{ "This is easy" | string.capitalizewords }}
 ```
@@ -2555,7 +2555,7 @@ Returns a boolean indicating whether the input string contains the specified str
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22This%20is%20easy%22%20%7C%20string.contains%20%22easy%22%20%7D%7D&model={})
 ```scriban-html
 {{ "This is easy" | string.contains "easy" }}
 ```
@@ -2585,7 +2585,7 @@ Returns a boolean indicating whether the input string is an empty string.
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22%22%20%7C%20string.empty%20%7D%7D&model={})
 ```scriban-html
 {{ "" | string.empty }}
 ```
@@ -2615,7 +2615,7 @@ Returns a boolean indicating whether the input string is empty or contains only 
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22%22%20%7C%20string.whitespace%20%7D%7D&model={})
 ```scriban-html
 {{ "" | string.whitespace }}
 ```
@@ -2645,7 +2645,7 @@ The input string lower case
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22TeSt%22%20%7C%20string.downcase%20%7D%7D&model={})
 ```scriban-html
 {{ "TeSt" | string.downcase }}
 ```
@@ -2676,7 +2676,7 @@ Returns a boolean indicating whether the input string ends with the specified st
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22This%20is%20easy%22%20%7C%20string.ends_with%20%22easy%22%20%7D%7D&model={})
 ```scriban-html
 {{ "This is easy" | string.ends_with "easy" }}
 ```
@@ -2707,7 +2707,7 @@ Returns a boolean indicating whether the input string is equal to specified stri
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22Scriban%22%20%7C%20string.equals_ignore_case%20%22SCRIBAN%22%20%7D%7D&model={})
 ```scriban-html
 {{ "Scriban" | string.equals_ignore_case "SCRIBAN" }}
 ```
@@ -2737,7 +2737,7 @@ A url handle
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%27100%25%20M%20%26%20Ms%21%21%21%27%20%7C%20string.handleize%20%20%7D%7D&model={})
 ```scriban-html
 {{ '100% M & Ms!!!' | string.handleize  }}
 ```
@@ -2768,7 +2768,7 @@ The literal of a string.
 #### Examples
 
 If the input string has non printable characters or they need contain a double quote, they will be escaped.
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%27Hello%5Cn%22World%22%27%20%7C%20string.literal%20%7D%7D&model={})
 ```scriban-html
 {{ 'Hello\n"World"' | string.literal }}
 ```
@@ -2798,7 +2798,7 @@ The input string without any left whitespace characters
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%27%20%20%20too%20many%20spaces%27%20%7C%20string.lstrip%20%20%7D%7D&model={})
 ```scriban-html
 {{ '   too many spaces' | string.lstrip  }}
 ```
@@ -2831,7 +2831,7 @@ The singular or plural string based on number
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20products.size%20%7D%7D%20%7B%7Bproducts.size%20%7C%20string.pluralize%20%27product%27%20%27products%27%20%7D%7D&model={})
 ```scriban-html
 {{ products.size }} {{products.size | string.pluralize 'product' 'products' }}
 ```
@@ -2862,7 +2862,7 @@ The two strings concatenated
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22World%22%20%7C%20string.prepend%20%22Hello%20%22%20%7D%7D&model={})
 ```scriban-html
 {{ "World" | string.prepend "Hello " }}
 ```
@@ -2893,7 +2893,7 @@ The input string with the all occurence of a substring removed
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22Hello%2C%20world.%20Goodbye%2C%20world.%22%20%7C%20string.remove%20%22world%22%20%7D%7D&model={})
 ```scriban-html
 {{ "Hello, world. Goodbye, world." | string.remove "world" }}
 ```
@@ -2924,7 +2924,7 @@ The input string with the first occurence of a substring removed
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22Hello%2C%20world.%20Goodbye%2C%20world.%22%20%7C%20string.remove_first%20%22world%22%20%7D%7D&model={})
 ```scriban-html
 {{ "Hello, world. Goodbye, world." | string.remove_first "world" }}
 ```
@@ -2955,7 +2955,7 @@ The input string with the first occurence of a substring removed
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22Hello%2C%20world.%20Goodbye%2C%20world.%22%20%7C%20string.remove_last%20%22world%22%20%7D%7D&model={})
 ```scriban-html
 {{ "Hello, world. Goodbye, world." | string.remove_last "world" }}
 ```
@@ -2987,7 +2987,7 @@ The input string replaced
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22Hello%2C%20world.%20Goodbye%2C%20world.%22%20%7C%20string.replace%20%22world%22%20%22buddy%22%20%7D%7D&model={})
 ```scriban-html
 {{ "Hello, world. Goodbye, world." | string.replace "world" "buddy" }}
 ```
@@ -3020,7 +3020,7 @@ The input string replaced
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22Hello%2C%20world.%20Goodbye%2C%20world.%22%20%7C%20string.replace_first%20%22world%22%20%22buddy%22%20%7D%7D&model={})
 ```scriban-html
 {{ "Hello, world. Goodbye, world." | string.replace_first "world" "buddy" }}
 ```
@@ -3050,7 +3050,7 @@ The input string without any left whitespace characters
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%27%20%20%20too%20many%20spaces%20%20%20%20%20%20%20%20%20%20%20%27%20%7C%20string.rstrip%20%20%7D%7D&model={})
 ```scriban-html
 {{ '   too many spaces           ' | string.rstrip  }}
 ```
@@ -3081,7 +3081,7 @@ The length of the input string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22test%22%20%7C%20string.size%20%7D%7D&model={})
 ```scriban-html
 {{ "test" | string.size }}
 ```
@@ -3114,7 +3114,7 @@ The input string sliced
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22hello%22%20%7C%20string.slice%200%20%7D%7D%0A%7B%7B%20%22hello%22%20%7C%20string.slice%201%20%7D%7D%0A%7B%7B%20%22hello%22%20%7C%20string.slice%201%203%20%7D%7D%0A%7B%7B%20%22hello%22%20%7C%20string.slice%201%20length%3A3%20%7D%7D&model={})
 ```scriban-html
 {{ "hello" | string.slice 0 }}
 {{ "hello" | string.slice 1 }}
@@ -3153,7 +3153,7 @@ The input string sliced
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22hello%22%20%7C%20string.slice1%200%20%7D%7D%0A%7B%7B%20%22hello%22%20%7C%20string.slice1%201%20%7D%7D%0A%7B%7B%20%22hello%22%20%7C%20string.slice1%201%203%20%7D%7D%0A%7B%7B%20%22hello%22%20%7C%20string.slice1%201%20length%3A%203%20%7D%7D&model={})
 ```scriban-html
 {{ "hello" | string.slice1 0 }}
 {{ "hello" | string.slice1 1 }}
@@ -3191,7 +3191,7 @@ An enumeration of the substrings
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20for%20word%20in%20%22Hi%2C%20how%20are%20you%20today%3F%22%20%7C%20string.split%20%27%20%27%20~%7D%7D%0A%7B%7B%20word%20%7D%7D%0A%7B%7B%20end%20~%7D%7D&model={})
 ```scriban-html
 {{ for word in "Hi, how are you today?" | string.split ' ' ~}}
 {{ word }}
@@ -3228,7 +3228,7 @@ Returns a boolean indicating whether the input string starts with the specified 
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22This%20is%20easy%22%20%7C%20string.starts_with%20%22This%22%20%7D%7D&model={})
 ```scriban-html
 {{ "This is easy" | string.starts_with "This" }}
 ```
@@ -3258,7 +3258,7 @@ The input string without any left and right whitespace characters
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%27%20%20%20too%20many%20spaces%20%20%20%20%20%20%20%20%20%20%20%27%20%7C%20string.strip%20%20%7D%7D&model={})
 ```scriban-html
 {{ '   too many spaces           ' | string.strip  }}
 ```
@@ -3289,7 +3289,7 @@ The input string without any breaks/newlines characters
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22This%20is%20a%20string.%5Cr%5Cn%20With%20%5Cnanother%20%5Crstring%22%20%7C%20string.strip_newlines%20%20%7D%7D&model={})
 ```scriban-html
 {{ "This is a string.\r\n With \nanother \rstring" | string.strip_newlines  }}
 ```
@@ -3319,7 +3319,7 @@ A 32 bit integer or null if conversion failed
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22123%22%20%7C%20string.to_int%20%2B%201%20%7D%7D&model={})
 ```scriban-html
 {{ "123" | string.to_int + 1 }}
 ```
@@ -3349,7 +3349,7 @@ A 64 bit integer or null if conversion failed
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22123678912345678%22%20%7C%20string.to_long%20%2B%201%20%7D%7D&model={})
 ```scriban-html
 {{ "123678912345678" | string.to_long + 1 }}
 ```
@@ -3379,7 +3379,7 @@ A 32 bit float or null if conversion failed
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22123.4%22%20%7C%20string.to_float%20%2B%201%20%7D%7D&model={})
 ```scriban-html
 {{ "123.4" | string.to_float + 1 }}
 ```
@@ -3409,7 +3409,7 @@ A 64 bit float or null if conversion failed
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22123.4%22%20%7C%20string.to_double%20%2B%201%20%7D%7D&model={})
 ```scriban-html
 {{ "123.4" | string.to_double + 1 }}
 ```
@@ -3442,7 +3442,7 @@ The truncated input string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22The%20cat%20came%20back%20the%20very%20next%20day%22%20%7C%20string.truncate%2013%20%7D%7D&model={})
 ```scriban-html
 {{ "The cat came back the very next day" | string.truncate 13 }}
 ```
@@ -3475,7 +3475,7 @@ The truncated input string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22The%20cat%20came%20back%20the%20very%20next%20day%22%20%7C%20string.truncatewords%204%20%7D%7D&model={})
 ```scriban-html
 {{ "The cat came back the very next day" | string.truncatewords 4 }}
 ```
@@ -3505,7 +3505,7 @@ The input string upper case
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22test%22%20%7C%20string.upcase%20%7D%7D&model={})
 ```scriban-html
 {{ "test" | string.upcase }}
 ```
@@ -3535,7 +3535,7 @@ The `md5` hash of the input string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22test%22%20%7C%20string.md5%20%7D%7D&model={})
 ```scriban-html
 {{ "test" | string.md5 }}
 ```
@@ -3565,7 +3565,7 @@ The `sha1` hash of the input string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22test%22%20%7C%20string.sha1%20%7D%7D&model={})
 ```scriban-html
 {{ "test" | string.sha1 }}
 ```
@@ -3595,7 +3595,7 @@ The `sha256` hash of the input string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22test%22%20%7C%20string.sha256%20%7D%7D&model={})
 ```scriban-html
 {{ "test" | string.sha256 }}
 ```
@@ -3626,7 +3626,7 @@ The `SHA-1` hash of the input string using a hash message authentication code (H
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22test%22%20%7C%20string.hmac_sha1%20%22secret%22%20%7D%7D&model={})
 ```scriban-html
 {{ "test" | string.hmac_sha1 "secret" }}
 ```
@@ -3657,7 +3657,7 @@ The `SHA-256` hash of the input string using a hash message authentication code 
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22test%22%20%7C%20string.hmac_sha256%20%22secret%22%20%7D%7D&model={})
 ```scriban-html
 {{ "test" | string.hmac_sha256 "secret" }}
 ```
@@ -3688,7 +3688,7 @@ The input string padded
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=hello%7B%7B%20%22world%22%20%7C%20string.pad_left%2010%20%7D%7D&model={})
 ```scriban-html
 hello{{ "world" | string.pad_left 10 }}
 ```
@@ -3719,7 +3719,7 @@ The input string padded
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22hello%22%20%7C%20string.pad_right%2010%20%7D%7Dworld&model={})
 ```scriban-html
 {{ "hello" | string.pad_right 10 }}world
 ```
@@ -3750,7 +3750,7 @@ The encoded string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22hello%22%20%7C%20string.base64_encode%20%7D%7D&model={})
 ```scriban-html
 {{ "hello" | string.base64_encode }}
 ```
@@ -3781,7 +3781,7 @@ The decoded string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22aGVsbG8%3D%22%20%7C%20string.base64_decode%20%7D%7D&model={})
 ```scriban-html
 {{ "aGVsbG8=" | string.base64_decode }}
 ```
@@ -3869,7 +3869,7 @@ A timespan object
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%28timespan.from_days%205%29.days%20%7D%7D&model={})
 ```scriban-html
 {{ (timespan.from_days 5).days }}
 ```
@@ -3899,7 +3899,7 @@ A timespan object
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%28timespan.from_hours%205%29.hours%20%7D%7D&model={})
 ```scriban-html
 {{ (timespan.from_hours 5).hours }}
 ```
@@ -3929,7 +3929,7 @@ A timespan object
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%28timespan.from_minutes%205%29.minutes%20%7D%7D&model={})
 ```scriban-html
 {{ (timespan.from_minutes 5).minutes }}
 ```
@@ -3959,7 +3959,7 @@ A timespan object
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%28timespan.from_seconds%205%29.seconds%20%7D%7D&model={})
 ```scriban-html
 {{ (timespan.from_seconds 5).seconds }}
 ```
@@ -3989,7 +3989,7 @@ A timespan object
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%28timespan.from_milliseconds%205%29.milliseconds%20%7D%7D&model={})
 ```scriban-html
 {{ (timespan.from_milliseconds 5).milliseconds }}
 ```

--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -3627,7 +3627,7 @@ The `sha512` hash of the input string
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22test%22%20%7C%20string.sha512%20%7D%7D&model={})
 ```scriban-html
 {{ "test" | string.sha512 }}
 ```
@@ -3720,7 +3720,7 @@ The `SHA-512` hash of the input string using a hash message authentication code 
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22test%22%20%7C%20string.hmac_sha512%20%22secret%22%20%7D%7D&model={})
 ```scriban-html
 {{ "test" | string.hmac_sha512 "secret" }}
 ```

--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -1205,7 +1205,7 @@ The input string with HTML line breaks
 
 #### Examples
 
-> **input**
+> **input** [:fast_forward: Try out](https://scribanonline.azurewebsites.net/?template=%7B%7B%20%22Hello%5Cnworld%22%20%7C%20html.newline_to_br%20%7D%7D&model={})
 ```scriban-html
 {{ "Hello\nworld" | html.newline_to_br }}
 ```

--- a/src/Scriban.DocGen/Program.cs
+++ b/src/Scriban.DocGen/Program.cs
@@ -114,7 +114,7 @@ This document describes the various built-in functions available in scriban.
             {
                 var type = member.Info as Type;
                 var methodInfo = member.Info as MethodInfo;
-               
+
 
                 if (type != null && IsBuiltinType(type, out string shortName))
                 {
@@ -146,7 +146,7 @@ This document describes the various built-in functions available in scriban.
 
                     // Write the toc
                     classWriter.Head.WriteLine($"- [`{shortName}.{methodShortName}`](#{shortName}{methodShortName})");
-                    
+
                     _writer = classWriter.Body;
                     _writer.WriteLine();
                     _writer.WriteLine("[:top:](#builtins)");
@@ -269,9 +269,24 @@ This document describes the various built-in functions available in scriban.
                 var content = text.Content;
 
                 content = content.Replace("```scriban-html", "> **input**\r\n```scriban-html");
+                content = AddTryOutLink(content);
                 content = content.Replace("```html", "> **output**\r\n```html");
 
                 _writer.Write(content);
+            }
+
+            private static string AddTryOutLink(string content)
+            {
+                const string startText = "\r\n```scriban-html\n";
+                var startIx = content.IndexOf(startText, StringComparison.Ordinal);
+                if (startIx == -1) return content;
+
+                const string endText = "\n```";
+                var enxIx = content.IndexOf(endText, startIx + startText.Length, StringComparison.Ordinal);
+
+                var template = content.Substring(startIx + startText.Length, enxIx - startIx - startText.Length);
+                var link = $"https://scribanonline.azurewebsites.net/?template={Uri.EscapeDataString(template)}&model={{}}";
+                return content.Replace("> **input**", $"> **input** [:fast_forward: Try out]({link})");
             }
 
             public override void VisitPara(Para para)


### PR DESCRIPTION
I have modified the `Scriban.DocGen` project to generate **:fast_forward: Try Out** links for each of the `scriban-html` examples in `builtins.md`

![image](https://github.com/user-attachments/assets/0ab61303-211c-4940-a1b3-1752acd07c89)

This links to https://scribanonline.azurewebsites.net with the template prefilled


Depends on PR https://github.com/nicholas-brooks/scribanonline/pull/17