### PR TITLE
Promote named args to local vars when using includes

### DIFF
--- a/src/Scriban.Tests/CustomTemplateLoader.cs
+++ b/src/Scriban.Tests/CustomTemplateLoader.cs
@@ -59,6 +59,9 @@ namespace Scriban.Tests
                 case "named_arguments":
                     return "{{ $.this_arg }}";
 
+                case "named_arguments_promoted":
+                    return "{{ $this_arg }}";
+
                 default:
                     return templatePath;
             }

--- a/src/Scriban.Tests/TestIncludes.cs
+++ b/src/Scriban.Tests/TestIncludes.cs
@@ -161,6 +161,18 @@ This is a header
         }
 
         [Test]
+        public void TestIncludePromotedNamedArguments()
+        {
+            var template = Template.Parse(@"{{ include 'named_arguments_promoted' this_arg: 5 }}");
+            var context = new TemplateContext();
+            context.TemplateLoader = new CustomTemplateLoader();
+
+            var text = template.Render(context).Replace("\r\n", "\n");
+            var expected = @"5";
+            TextAssert.AreEqual(expected, text);
+        }
+
+        [Test]
         public void TestIndentedIncludes()
         {
             var template = Template.Parse(@"  {{ include 'header' }}

--- a/src/Scriban/TemplateContext.cs
+++ b/src/Scriban/TemplateContext.cs
@@ -1288,11 +1288,12 @@ namespace Scriban
         /// <summary>
         /// Promotes named arguments in a script function call to local variables within the current context.
         /// </summary>
-        private void PromoteScriptNamedArguments(ScriptNode scriptNode)
+        private IReadOnlyList<ScriptVariable> PromoteScriptNamedArguments(ScriptNode scriptNode)
         {
+            var newVariables = new List<ScriptVariable>();
             if (!(scriptNode is ScriptFunctionCall sfc))
             {
-                return;
+                return Array.Empty<ScriptVariable>();
             }
 
             foreach (var item in sfc.Arguments)
@@ -1304,7 +1305,9 @@ namespace Scriban
                 // add a local variable for each named argument
                 var newLocalVariable = ScriptVariable.Create(sna.Name.Name, ScriptVariableScope.Local);
                 SetValue(variable: newLocalVariable, value: sna.Value, asReadOnly: true, force: true);
+                newVariables.Add(newLocalVariable);
             }
+            return newVariables.ToArray();
         }
 
         public string RenderTemplate(Template template, ScriptArray arguments, ScriptNode callerContext)
@@ -1316,10 +1319,11 @@ namespace Scriban
             CurrentIndent = null;
             PushOutput();
             var previousArguments = GetValue(ScriptVariable.Arguments);
+            IReadOnlyList<ScriptVariable> promotedVariables = Array.Empty<ScriptVariable>();
             try
             {
                 SetValue(ScriptVariable.Arguments, arguments, true, true);
-                PromoteScriptNamedArguments(callerContext);
+                promotedVariables = PromoteScriptNamedArguments(callerContext);
                 if (previousIndent != null)
                 {
                     // We reset before and after the fact that we have a new line
@@ -1339,6 +1343,11 @@ namespace Scriban
 
                 // Remove the arguments
                 DeleteValue(ScriptVariable.Arguments);
+                // Remove any promoted variables
+                foreach (var v in promotedVariables)
+                {
+                    DeleteValue(v);
+                }
                 if (previousArguments != null)
                 {
                     // Restore them if necessary


### PR DESCRIPTION
Addresses #171.

I'm not sure this is the correct way to implement this, but the tests pass :-)...  Any feedback?

Given:
```
{{ include 'named_arguments_promoted' this_arg: 5 }}
```

In the template you can use:
```
{{ $this_arg }}
```

Without breaking this:
```
{{ $.this_arg }}
```
