### PR TITLE
Fix `Include` named arg values being lost for nested includes

### DIFF
--- a/src/Scriban.Tests/CustomTemplateLoader.cs
+++ b/src/Scriban.Tests/CustomTemplateLoader.cs
@@ -72,6 +72,21 @@ namespace Scriban.Tests
                         {{ $.y | object.typeof }}::{{ $.y }}=={{ $y | object.typeof }}::{{ $y }}
                         """;
 
+                case "named_arguments_promoted_persist_1":
+                    return """
+                        {{- x = $_ -}}
+                        ORG({{ $_ | object.keys }})
+                        X({{ x | object.keys }})
+                        {{ for c in $_.header.components2 -}}
+                        {{ include 'named_arguments_promoted_persist_2' _:c }}
+                        {{- end }}
+                        ORG({{ $_ | object.keys }})
+                        X({{ x | object.keys }})
+                        """;
+
+                case "named_arguments_promoted_persist_2":
+                    return "OUT({{- $_ -}})";
+
                 default:
                     return templatePath;
             }

--- a/src/Scriban.Tests/TestIncludes.cs
+++ b/src/Scriban.Tests/TestIncludes.cs
@@ -202,6 +202,45 @@ This is a header
         }
 
         [Test]
+        public void TestIncludePromotedNamedArguments_persist()
+        {
+            var rawTemplate = """
+                {{- for c in components1 -}}
+                {{- include 'named_arguments_promoted_persist_1' _:c -}}
+                {{- end -}}
+                """;
+
+            var template = Template.Parse( rawTemplate );
+            var context = new TemplateContext();
+            context.TemplateLoader = new CustomTemplateLoader();
+            var model = new
+            {
+                components1 = new object[] {
+                    new {
+                        header = new {
+                            components2 = new object[] {
+                                new {
+                                    key = "A"
+                                }
+                            }
+                        }
+                    },
+                }
+            };
+            context.PushGlobal( ScriptObject.From(model) );
+
+            var text = template.Render( context ).Replace( "\r\n", "\n" );
+            var expected = """
+                ORG(["header"])
+                X(["header"])
+                OUT({ key = A })
+                ORG(["header"])
+                X(["header"])
+                """.Replace( "\r\n", "\n" );
+            TextAssert.AreEqual( expected, text );
+        }
+
+        [Test]
         public void TestIndentedIncludes()
         {
             var template = Template.Parse(@"  {{ include 'header' }}

--- a/src/Scriban/Runtime/CustomFunction.Generated.cs
+++ b/src/Scriban/Runtime/CustomFunction.Generated.cs
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------------
-// This file was automatically generated - 11/17/2025 08:03:34 by Scriban.DelegateCodeGen
+// This file was automatically generated - 03/05/2026 20:22:59 by Scriban.DelegateCodeGen
 // DOT NOT EDIT THIS FILE MANUALLY
 // ----------------------------------------------------------------------------------
 

--- a/src/Scriban/ScribanAsync.generated.cs
+++ b/src/Scriban/ScribanAsync.generated.cs
@@ -377,6 +377,17 @@ namespace Scriban
 
         public async ValueTask<string> RenderTemplateAsync(Template template, ScriptArray arguments, ScriptNode callerContext)
         {
+            // Fetch and remember any named argument values so they can be added as local variables for the template and then restored after rendering the template
+            var namedArguments = (callerContext as ScriptFunctionCall)?.Arguments.OfType<ScriptNamedArgument>().ToArray();
+            var previousNamedArgumentValues = new Dictionary<ScriptVariable, object>();
+            foreach (var v in namedArguments)
+            {
+                var name = v.Name.Name;
+                var namedArgumentVariable = ScriptVariable.Create(name, ScriptVariableScope.Local);
+                var value = await namedArgumentVariable.EvaluateAsync(this).ConfigureAwait(false);
+                previousNamedArgumentValues[v.Name] = value;
+            }
+
             // Make sure that we cannot recursively include a template
             string result = null;
             EnterRecursive(callerContext);
@@ -384,11 +395,17 @@ namespace Scriban
             CurrentIndent = null;
             PushOutput();
             var previousArguments = await GetValueAsync(ScriptVariable.Arguments).ConfigureAwait(false);
-            IReadOnlyList<ScriptVariable> promotedVariables = Array.Empty<ScriptVariable>();
             try
             {
                 SetValue(ScriptVariable.Arguments, arguments, true, true);
-                promotedVariables = PromoteScriptNamedArguments(callerContext);
+                // Add local variables for each named argument
+                foreach (var kv in namedArguments)
+                {
+                    var name = kv.Name.Name;
+                    var value = await kv.Value.EvaluateAsync(this).ConfigureAwait(false);
+                    var newLocalVariable = ScriptVariable.Create(name, ScriptVariableScope.Local);
+                    SetValue(variable: newLocalVariable, value: value, asReadOnly: false, force: true);
+                }
                 if (previousIndent != null)
                 {
                     // We reset before and after the fact that we have a new line
@@ -408,15 +425,19 @@ namespace Scriban
 
                 // Remove the arguments
                 DeleteValue(ScriptVariable.Arguments);
-                // Remove any promoted variables
-                foreach (var v in promotedVariables)
-                {
-                    DeleteValue(v);
-                }
                 if (previousArguments != null)
                 {
                     // Restore them if necessary
                     SetValue(ScriptVariable.Arguments, previousArguments, true);
+                }
+                // Remove the local variables we added for the named arguments and restore their previous value if necessary
+                foreach (var kv in previousNamedArgumentValues)
+                {
+                    DeleteValue(kv.Key);
+                    var name = kv.Key.Name;
+                    var value = kv.Value;
+                    var namedArgumentVariable = ScriptVariable.Create(name, ScriptVariableScope.Local);
+                    SetValue(variable: namedArgumentVariable, value: value, asReadOnly: false, force: true);
                 }
             }
             return result;

--- a/src/Scriban/TemplateContext.cs
+++ b/src/Scriban/TemplateContext.cs
@@ -4,6 +4,12 @@
 
 #nullable disable
 
+using Scriban.Functions;
+using Scriban.Helpers;
+using Scriban.Parsing;
+using Scriban.Runtime;
+using Scriban.Runtime.Accessors;
+using Scriban.Syntax;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -15,12 +21,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Scriban.Functions;
-using Scriban.Helpers;
-using Scriban.Parsing;
-using Scriban.Runtime;
-using Scriban.Runtime.Accessors;
-using Scriban.Syntax;
+using System.Xml.Linq;
 
 #if !SCRIBAN_SIGNED
 [assembly: InternalsVisibleTo("Scriban.Tests")]
@@ -1285,35 +1286,19 @@ namespace Scriban
             return template;
         }
 
-        /// <summary>
-        /// Promotes named arguments in a script function call to local variables within the current context.
-        /// </summary>
-        private IReadOnlyList<ScriptVariable> PromoteScriptNamedArguments(ScriptNode scriptNode)
-        {
-            var newVariables = new List<ScriptVariable>();
-            if (!(scriptNode is ScriptFunctionCall sfc))
-            {
-                return Array.Empty<ScriptVariable>();
-            }
-
-            foreach (var item in sfc.Arguments)
-            {
-                if (!(item is ScriptNamedArgument sna))
-                {
-                    continue;
-                }
-                // add a local variable for each named argument
-                var name = sna.Name.Name;
-                var value = sna.Value.Evaluate(this);
-                var newLocalVariable = ScriptVariable.Create(name, ScriptVariableScope.Local);
-                SetValue(variable: newLocalVariable, value: value, asReadOnly: true, force: true);
-                newVariables.Add(newLocalVariable);
-            }
-            return newVariables.ToArray();
-        }
-
         public string RenderTemplate(Template template, ScriptArray arguments, ScriptNode callerContext)
         {
+            // Fetch and remember any named argument values so they can be added as local variables for the template and then restored after rendering the template
+            var namedArguments = (callerContext as ScriptFunctionCall)?.Arguments.OfType<ScriptNamedArgument>().ToArray();
+            var previousNamedArgumentValues = new Dictionary<ScriptVariable, object>();
+            foreach (var v in namedArguments)
+            {
+                var name = v.Name.Name;
+                var namedArgumentVariable = ScriptVariable.Create(name, ScriptVariableScope.Local);
+                var value = namedArgumentVariable.Evaluate(this);
+                previousNamedArgumentValues[v.Name] = value;
+            }
+
             // Make sure that we cannot recursively include a template
             string result = null;
             EnterRecursive(callerContext);
@@ -1321,11 +1306,17 @@ namespace Scriban
             CurrentIndent = null;
             PushOutput();
             var previousArguments = GetValue(ScriptVariable.Arguments);
-            IReadOnlyList<ScriptVariable> promotedVariables = Array.Empty<ScriptVariable>();
             try
             {
                 SetValue(ScriptVariable.Arguments, arguments, true, true);
-                promotedVariables = PromoteScriptNamedArguments(callerContext);
+                // Add local variables for each named argument
+                foreach (var kv in namedArguments)
+                {
+                    var name = kv.Name.Name;
+                    var value = kv.Value.Evaluate(this);
+                    var newLocalVariable = ScriptVariable.Create(name, ScriptVariableScope.Local);
+                    SetValue(variable: newLocalVariable, value: value, asReadOnly: false, force: true);
+                }
                 if (previousIndent != null)
                 {
                     // We reset before and after the fact that we have a new line
@@ -1345,15 +1336,19 @@ namespace Scriban
 
                 // Remove the arguments
                 DeleteValue(ScriptVariable.Arguments);
-                // Remove any promoted variables
-                foreach (var v in promotedVariables)
-                {
-                    DeleteValue(v);
-                }
                 if (previousArguments != null)
                 {
                     // Restore them if necessary
                     SetValue(ScriptVariable.Arguments, previousArguments, true);
+                }
+                // Remove the local variables we added for the named arguments and restore their previous value if necessary
+                foreach (var kv in previousNamedArgumentValues)
+                {
+                    DeleteValue(kv.Key);
+                    var name = kv.Key.Name;
+                    var value = kv.Value;
+                    var namedArgumentVariable = ScriptVariable.Create(name, ScriptVariableScope.Local);
+                    SetValue(variable: namedArgumentVariable, value: value, asReadOnly: false, force: true);
                 }
             }
             return result;


### PR DESCRIPTION
Named argument values weren't being restored correctly if the same arg. name was being used for nested includes.

This PR includes a test case and a fix for the issue.
