### PR TITLE
Cleanup `Include` remove magic checks

### DIFF
--- a/src/Scriban/TemplateContext.Variables.cs
+++ b/src/Scriban/TemplateContext.Variables.cs
@@ -213,6 +213,7 @@ namespace Scriban
         /// </summary>
         /// <param name="variable">The variable to retrieve the value</param>
         /// <returns>Value of the variable</returns>
+        /// <exception cref="ScriptRuntimeException">If <see cref="StrictVariables"/> is enabled and the specified variable is undefined.</exception>
         public object GetValue(ScriptVariable variable)
         {
             if (variable == null) throw new ArgumentNullException(nameof(variable));
@@ -245,6 +246,7 @@ namespace Scriban
         /// </summary>
         /// <param name="variable">The variable to retrieve the value</param>
         /// <returns>Value of the variable</returns>
+        /// <exception cref="ScriptRuntimeException">If <see cref="StrictVariables"/> is enabled and the specified variable is undefined.</exception>
         public object GetValue(ScriptVariableGlobal variable)
         {
             if (variable == null) throw new ArgumentNullException(nameof(variable));


### PR DESCRIPTION
I was lurking around the code and found another `magic check`.
Following PR #649 and #650, this logic is no longer needed and can be remove.
Added some summary exception notes to `GetValue`.