### PR TITLE
Remove legacy demo from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,7 +163,7 @@ This software is released under the [BSD-Clause 2 license](https://opensource.or
 ## Online Demo
 
 * Main site and playground: https://scriban.github.io
-* Legacy sample: https://scribanonline.azurewebsites.net/ ASP.NET Core sample
+
 
 ## Sponsors
 


### PR DESCRIPTION
As there is now an official online demo (thanks @xoofx!), there isn't a need for the legacy demo, so I'll shut it down and remove the resources.  The repository will be archived but still be available at https://github.com/nicholas-brooks/scribanonline.