### PR TITLE
Adding nullable support to is_number function

### DIFF
--- a/src/Scriban.Tests/TestFiles/400-builtins/420-math.out.txt
+++ b/src/Scriban.Tests/TestFiles/400-builtins/420-math.out.txt
@@ -8,4 +8,5 @@
 true
 true
 false
+false
 4.24

--- a/src/Scriban.Tests/TestFiles/400-builtins/420-math.txt
+++ b/src/Scriban.Tests/TestFiles/400-builtins/420-math.txt
@@ -8,4 +8,5 @@
 {{ 4.5 | math.is_number }}
 {{ 4 | math.is_number }}
 {{ "toto" | math.is_number }}
+{{ null | math.is_number }}
 {{ 4.2435 | math.format "0.##" }}

--- a/src/Scriban/Functions/MathFunctions.cs
+++ b/src/Scriban/Functions/MathFunctions.cs
@@ -215,7 +215,7 @@ namespace Scriban.Functions
         /// false
         /// ```
         /// </remarks>
-        public static bool IsNumber(object value)
+        public static bool IsNumber(object? value)
         {
             return value is sbyte
                    || value is byte


### PR DESCRIPTION
This used to work before nullable annotation were introduced, similar to https://github.com/scriban/scriban/issues/661

Note: I have updated the `420-math.txt` and `420-math.out.txt` but I could not get the tests to fail, even with clearly wrong `420-math.out.txt`. Are tests working as expected?!